### PR TITLE
feat: centralize env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# === LLM providers ===
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+GOOGLE_API_KEY=
+
+# === Databases ===
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+POSTGRES_DB=trainium
+POSTGRES_USER=trainium
+POSTGRES_PASSWORD=changeme
+
+MONGO_HOST=mongo
+MONGO_PORT=27017
+MONGO_DB=trainium
+
+# === Kong (DB-less mode) ===
+KONG_LOG_LEVEL=info
+KONG_ADMIN_LISTEN=0.0.0.0:8001
+
+# === App ===
+ENVIRONMENT=local

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+.env.*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This guide explains required **environment variables** and **startup steps** for
 ---
 
 ## 1) Environment Variables (.env)
-Create a file named `.env` in the repo root with the values below. You can copy this block into `.env` and update as needed. Do **not** commit real secrets.
+Copy `.env.example` to `.env` in the repo root and update as needed. Do **not** commit real secrets.
 
 ```bash
 # === LLM providers ===
@@ -20,13 +20,15 @@ ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=   # for Gemini (google-generativeai)
 
 # === Databases ===
-POSTGRES_USER=trainium
-POSTGRES_PASSWORD=devpassword
-POSTGRES_DB=trainium
+POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
+POSTGRES_DB=trainium
+POSTGRES_USER=trainium
+POSTGRES_PASSWORD=changeme
 
-MONGO_INITDB_DATABASE=trainium
+MONGO_HOST=mongo
 MONGO_PORT=27017
+MONGO_DB=trainium
 
 # === Kong (DB-less mode) ===
 KONG_LOG_LEVEL=info
@@ -40,13 +42,13 @@ ENVIRONMENT=local
 
 ### Variable reference
 - **OPENAI_API_KEY / ANTHROPIC_API_KEY / GOOGLE_API_KEY**: Optional for now; used by Agents when hitting LLMs.
-- **POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB / POSTGRES_PORT**: Credentials and port for the Postgres container.
-- **MONGO_INITDB_DATABASE / MONGO_PORT**: Initial DB and port for Mongo.
+- **POSTGRES_HOST / POSTGRES_PORT / POSTGRES_DB / POSTGRES_USER / POSTGRES_PASSWORD**: Connection settings for the Postgres container.
+- **MONGO_HOST / MONGO_PORT / MONGO_DB**: Connection settings for the Mongo container.
 - **KONG_LOG_LEVEL**: Kong log verbosity (`info`, `debug`, etc.).
 - **KONG_ADMIN_LISTEN**: Admin API bind (enabled only in dev).
 - **ENVIRONMENT**: Passed to the Agents service for environment-aware behavior.
 
-Create a **`.env.example`** (checked in) with safe placeholders so others can copy it to `.env` quickly.
+An **`.env.example`** is checked in with safe placeholders so others can copy it to `.env` quickly.
 
 ---
 

--- a/agents/app/config.py
+++ b/agents/app/config.py
@@ -5,15 +5,15 @@ class Settings(BaseModel):
     environment: str = os.getenv("ENVIRONMENT", "local")
 
     # DBs
-    pg_host: str = os.getenv("POSTGRES_HOST", "postgres")
-    pg_port: int = int(os.getenv("POSTGRES_PORT", "5432"))
-    pg_db: str   = os.getenv("POSTGRES_DB", "trainium")
-    pg_user: str = os.getenv("POSTGRES_USER", "trainium")
-    pg_pass: str = os.getenv("POSTGRES_PASSWORD", "devpassword")
+    pg_host: str = os.getenv("POSTGRES_HOST")
+    pg_port: int = int(os.getenv("POSTGRES_PORT"))
+    pg_db: str   = os.getenv("POSTGRES_DB")
+    pg_user: str = os.getenv("POSTGRES_USER")
+    pg_pass: str = os.getenv("POSTGRES_PASSWORD")
 
-    mongo_host: str = os.getenv("MONGO_HOST", "mongo")
-    mongo_port: int = int(os.getenv("MONGO_PORT", "27017"))
-    mongo_db:   str = os.getenv("MONGO_DB", "trainium")
+    mongo_host: str = os.getenv("MONGO_HOST")
+    mongo_port: int = int(os.getenv("MONGO_PORT"))
+    mongo_db:   str = os.getenv("MONGO_DB")
 
     # LLM keys
     openai_api_key: str | None = os.getenv("OPENAI_API_KEY")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ name: trainium
 services:
   kong:
     image: kong:3.6
+    env_file:
+      - .env
     depends_on:
       - frontend
       - agents
@@ -39,13 +41,14 @@ services:
       - .env
     environment:
       ENVIRONMENT: ${ENVIRONMENT}
-      POSTGRES_HOST: postgres
+      POSTGRES_HOST: ${POSTGRES_HOST}
       POSTGRES_PORT: ${POSTGRES_PORT}
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      MONGO_HOST: mongo
+      MONGO_HOST: ${MONGO_HOST}
       MONGO_PORT: ${MONGO_PORT}
+      MONGO_DB: ${MONGO_DB}
       # LLM keys (also pulled from env_file)
       OPENAI_API_KEY: ${OPENAI_API_KEY}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
@@ -78,6 +81,8 @@ services:
     image: mongo:7
     env_file:
       - .env
+    environment:
+      MONGO_INITDB_DATABASE: ${MONGO_DB}
     volumes:
       - mongodata:/data/db
     ports:


### PR DESCRIPTION
## Summary
- centralize service configuration via .env file
- remove hardcoded database credentials
- document environment variables and include `.env.example`
- broaden gitignore to cover local env variants and ensure files end with a newline

## Testing
- `python -m py_compile agents/app/config.py`
- `pytest`
- `docker compose config` *(fails: command not found)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afc413283c8330b8ce727a4a7cdcf6