### PR TITLE
feat: add health checks and docs for docker stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This guide explains required **environment variables** and **startup steps** for
 - Agents API (FastAPI)
 - PostgreSQL (relational)
 - MongoDB (document)
+  
+Persistent data for Postgres and Mongo is stored in named Docker volumes (`pgdata`, `mongodata`) so database contents survive restarts.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,10 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       GOOGLE_API_KEY: ${GOOGLE_API_KEY}
     depends_on:
-      - postgres
-      - mongo
+      postgres:
+        condition: service_healthy
+      mongo:
+        condition: service_healthy
     expose:
       - "8000"
     networks: [trainium-net]
@@ -76,6 +78,11 @@ services:
       - "5432:5432"      # expose for local tools (optional)
     networks: [trainium-net]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   mongo:
     image: mongo:7
@@ -89,6 +96,11 @@ services:
       - "27017:27017"    # expose for local tools (optional)
     networks: [trainium-net]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 networks:
   trainium-net:


### PR DESCRIPTION
## Summary
- ensure Postgres and Mongo wait for healthy state before Agents starts
- document persistent database volumes for onboarding clarity

## Testing
- `python -m py_compile agents/app/*.py`
- `python -c 'import yaml,sys; yaml.safe_load(open("gateway/kong.yml"))'`


------
https://chatgpt.com/codex/tasks/task_e_68afca0da12883308a47aaf330156bf9