### PR TITLE
feat: add health endpoints and smoke test

### DIFF
--- a/agents/app/main.py
+++ b/agents/app/main.py
@@ -1,4 +1,5 @@
-import os
+from typing import Any, Tuple
+
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse, PlainTextResponse
 import psycopg2
@@ -9,13 +10,19 @@ from .config import settings
 app = FastAPI(title="Trainium Agents API", version="0.1.0")
 
 @app.get("/health", response_class=JSONResponse)
-def health():
+def health() -> dict[str, Any]:
     return {
         "status": "ok",
         "environment": settings.environment,
         "services": {
-            "postgres": {"host": settings.pg_host, "port": settings.pg_port},
-            "mongo": {"host": settings.mongo_host, "port": settings.mongo_port},
+            "postgres": {
+                "host": settings.pg_host,
+                "port": settings.pg_port,
+            },
+            "mongo": {
+                "host": settings.mongo_host,
+                "port": settings.mongo_port,
+            },
         },
         "llm_providers": {
             "openai": bool(settings.openai_api_key),
@@ -26,45 +33,71 @@ def health():
     }
 
 
-# Health check endpoint for DBs
-@app.get("/health/db", response_class=JSONResponse)
-def health_db():
-    errors = {}
-    # Check Postgres
+def _check_postgres() -> Tuple[bool, str | None]:
     try:
         conn = psycopg2.connect(
             host=settings.pg_host,
             port=settings.pg_port,
             user=settings.pg_user,
-            password=settings.pg_password,
+            password=settings.pg_pass,
             dbname=settings.pg_db,
-            connect_timeout=2
+            connect_timeout=2,
         )
         conn.close()
-        pg_status = True
-    except Exception as e:
-        errors['postgres'] = str(e)
-        pg_status = False
-    # Check Mongo
+        return True, None
+    except Exception as exc:  # pragma: no cover - network dependent
+        return False, str(exc)
+
+
+def _check_mongo() -> Tuple[bool, str | None]:
     try:
-        mongo_uri = f"mongodb://{settings.mongo_user}:{settings.mongo_password}@{settings.mongo_host}:{settings.mongo_port}"
-        client = MongoClient(mongo_uri, serverSelectionTimeoutMS=2000)
-        # The following will force a connection call
-        client.admin.command('ping')
+        client = MongoClient(
+            host=settings.mongo_host,
+            port=settings.mongo_port,
+            serverSelectionTimeoutMS=2000,
+        )
+        client.admin.command("ping")
         client.close()
-        mongo_status = True
-    except Exception as e:
-        errors['mongo'] = str(e)
-        mongo_status = False
-    if pg_status and mongo_status:
-        status_str = "ok"
-    else:
-        status_str = "degraded"
-    resp = {"status": status_str}
-    if errors:
-        resp["errors"] = errors
+        return True, None
+    except Exception as exc:  # pragma: no cover - network dependent
+        return False, str(exc)
+
+
+@app.get("/health/postgres", response_class=JSONResponse)
+def health_postgres() -> dict[str, Any]:
+    ok, err = _check_postgres()
+    resp: dict[str, Any] = {
+        "status": "ok" if ok else "error",
+        "service": "postgres",
+        "host": settings.pg_host,
+        "port": settings.pg_port,
+    }
+    if err:
+        resp["error"] = err
     return resp
 
+
+@app.get("/health/mongo", response_class=JSONResponse)
+def health_mongo() -> dict[str, Any]:
+    ok, err = _check_mongo()
+    resp: dict[str, Any] = {
+        "status": "ok" if ok else "error",
+        "service": "mongo",
+        "host": settings.mongo_host,
+        "port": settings.mongo_port,
+    }
+    if err:
+        resp["error"] = err
+    return resp
+
+
+@app.get("/health/db", response_class=JSONResponse)
+def health_db() -> dict[str, Any]:
+    pg = health_postgres()
+    mg = health_mongo()
+    status = "ok" if pg["status"] == "ok" and mg["status"] == "ok" else "degraded"
+    return {"status": status, "postgres": pg, "mongo": mg}
+
 @app.get("/", response_class=PlainTextResponse)
-def root():
+def root() -> str:
     return "Trainium Agents API. See /health"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-http://localhost:8000}
+
+check() {
+  local path="$1"
+  local name="$2"
+  echo "Checking $name at $BASE_URL$path"
+  resp=$(curl -fsS "$BASE_URL$path")
+  echo "$resp"
+  echo "$resp" | grep -q '"status"[[:space:]]*:[[:space:]]*"ok"'
+}
+
+check /health frontend
+check /api/health agents
+check /api/health/postgres postgres
+check /api/health/mongo mongo
+
+echo "All health checks passed."


### PR DESCRIPTION
## Summary
- add typed health endpoints for Postgres and Mongo
- expose combined database health check
- provide smoke test script for core services

## Testing
- `python -m py_compile agents/app/*.py`
- `bash scripts/smoke_test.sh` *(fails: Failed to connect to localhost port 8000)*

------
https://chatgpt.com/codex/tasks/task_e_68afdd24e388833088f7cea6bfc7f256