### PR TITLE
feat: load env vars from dot env

### DIFF
--- a/agents/app/config.py
+++ b/agents/app/config.py
@@ -1,5 +1,9 @@
 import os
+from dotenv import load_dotenv
 from pydantic import BaseModel
+
+# Load variables from .env if present
+load_dotenv()
 
 class Settings(BaseModel):
     environment: str = os.getenv("ENVIRONMENT", "local")

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Load variables from .env if available
+if [ -f ".env" ]; then
+  set -o allexport
+  source .env
+  set +o allexport
+fi
+
 BASE_URL=${BASE_URL:-http://localhost:8000}
 
 check() {


### PR DESCRIPTION
## Summary
- load .env variables into the Agents service configuration
- source .env in smoke test script so health checks use shared config

## Testing
- `python -m py_compile agents/app/*.py`
- `python -c 'import yaml,sys; yaml.safe_load(open("gateway/kong.yml"))'`


------
https://chatgpt.com/codex/tasks/task_e_68afdf156eb48330b5ca124f354b411b