### PR TITLE
feat: add CrewAI agent endpoint

### DIFF
--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -16,3 +16,4 @@ crewai==0.159.0
 # DB clients
 psycopg2-binary==2.9.10
 pymongo==4.14.1
+


### PR DESCRIPTION
## Summary
- integrate CrewAI into agents service
- add `/api/agent/{persona}` endpoint that echoes input
- include CrewAI in requirements

## Testing
- `python -m py_compile agents/app/*.py`
- `python - <<'PY'
import os
os.environ.update({'ENVIRONMENT':'test','POSTGRES_HOST':'localhost','POSTGRES_PORT':'5432','POSTGRES_USER':'u','POSTGRES_PASS':'p','POSTGRES_DB':'d','MONGO_HOST':'localhost','MONGO_PORT':'27017','OPENAI_API_KEY':'','ANTHROPIC_API_KEY':'','GOOGLE_API_KEY':''})
from fastapi.testclient import TestClient
from agents.app.main import app
client = TestClient(app)
print(client.post('/api/agent/test', json={'message': 'hello'}).json())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68afe1feb8b48330a779d6c5250564c1