### PR TITLE
feat: add feedback API

### DIFF
--- a/scripts/migrations/001_create_feedback.sql
+++ b/scripts/migrations/001_create_feedback.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS feedback (
+    id SERIAL PRIMARY KEY,
+    persona TEXT NOT NULL,
+    input TEXT NOT NULL,
+    output TEXT NOT NULL,
+    feedback TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add /feedback endpoint for reviewers
- persist reviewer input in postgres and expose query endpoint
- track schema with feedback table migration

## Testing
- `python -m py_compile agents/app/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afeb9419288330b6680edcaba0afd6