### PR TITLE
test: add smoke tests for agents layer

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,29 @@
+name: Smoke Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Copy env
+        run: cp .env.example .env
+      - name: Build and run stack
+        run: docker compose up -d --build
+      - name: Wait for services
+        run: |
+          for i in {1..10}; do
+            if curl -fsS http://localhost:8000/health >/dev/null 2>&1; then
+              exit 0
+            fi
+            sleep 5
+          done
+          exit 1
+      - name: Run smoke tests
+        run: ./scripts/smoke_test.sh
+      - name: Tear down
+        if: always()
+        run: docker compose down -v

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -25,3 +25,29 @@ check /api/health/postgres postgres
 check /api/health/mongo mongo
 
 echo "All health checks passed."
+
+# === Agents layer smoke tests ===
+
+# Validate /api/personas returns a JSON array with at least one persona
+echo "Checking personas catalog"
+personas_resp=$(curl -fsS "$BASE_URL/api/personas")
+echo "$personas_resp"
+echo "$personas_resp" | python -m json.tool >/dev/null
+echo "$personas_resp" | grep -q '"id"'
+
+# Validate /api/agent/{persona} returns JSON on POST
+echo "Checking agent endpoint"
+agent_resp=$(curl -fsS -H 'Content-Type: application/json' \
+  -d '{"input":"ping"}' "$BASE_URL/api/agent/test")
+echo "$agent_resp"
+echo "$agent_resp" | python -m json.tool >/dev/null
+
+# Validate /feedback persists data to Postgres via Agents service
+echo "Checking feedback persistence"
+payload='{ "persona": "smoke", "input": "hi", "output": "hello", "feedback": "ok" }'
+post_resp=$(curl -fsS -H 'Content-Type: application/json' -d "$payload" "$BASE_URL/api/feedback")
+echo "$post_resp" | python -m json.tool >/dev/null
+feedback_list=$(curl -fsS "$BASE_URL/api/feedback")
+echo "$feedback_list" | grep -q '"persona"[[:space:]]*:[[:space:]]*"smoke"'
+
+echo "All smoke tests passed."


### PR DESCRIPTION
## Summary
- extend smoke_test.sh to exercise /api/personas, /api/agent and /api/feedback endpoints
- add GitHub Actions workflow to run Docker stack and smoke tests

## Testing
- `python -m py_compile agents/app/*.py`
- `pytest`
- `./scripts/smoke_test.sh` *(fails: Failed to connect to localhost port 8000)*
- `docker compose up -d --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afed5fa2708330888ab0fc657c7f9c