### PR TITLE
feat: add jobspy microservice scaffold

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     depends_on:
       - frontend
       - agents
+      - jobspy
     environment:
       KONG_DATABASE: "off"
       KONG_DECLARATIVE_CONFIG: "/etc/kong/kong.yml"
@@ -58,6 +59,14 @@ services:
         condition: service_healthy
       mongo:
         condition: service_healthy
+    expose:
+      - "8000"
+    networks: [trainium-net]
+    restart: unless-stopped
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 2 --proxy-headers
+
+  jobspy:
+    build: ./jobspy
     expose:
       - "8000"
     networks: [trainium-net]

--- a/gateway/kong.yml
+++ b/gateway/kong.yml
@@ -32,3 +32,11 @@ services:
               add:
                 headers:
                   - "X-Through-Kong: true"
+
+  # JobSpy service (served via Kong at /jobs)
+  - name: jobspy
+    url: http://jobspy:8000
+    routes:
+      - name: jobspy-api
+        paths: ["/jobs"]
+        strip_path: false

--- a/jobspy/Dockerfile
+++ b/jobspy/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN python -m pip install -U pip && \
+    python -m pip install -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 8000
+CMD ["uvicorn","app.main:app","--host=0.0.0.0","--port=8000","--workers=2","--proxy-headers"]

--- a/jobspy/app/main.py
+++ b/jobspy/app/main.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+
+app = FastAPI(title="JobSpy API", version="0.1.0")
+
+
+@app.get("/jobs/search", response_class=JSONResponse)
+def search_jobs() -> dict[str, Any]:
+    """Return mock job search results."""
+    return {"jobs": []}

--- a/jobspy/requirements.txt
+++ b/jobspy/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.0
+uvicorn==0.27.1


### PR DESCRIPTION
## Summary
- scaffold JobSpy FastAPI service with mock `/jobs/search` endpoint
- wire JobSpy into Docker Compose and Kong routing

## Testing
- `python -m py_compile jobspy/app/*.py`
- `python -c 'import yaml,sys; yaml.safe_load(open("gateway/kong.yml"))'`


------
https://chatgpt.com/codex/tasks/task_e_68aff5db32f08330a4c4985a19c0218a