### PR TITLE
feat(jobspy): add LinkedIn source and request delay

### DIFF
--- a/jobspy/.env.example
+++ b/jobspy/.env.example
@@ -1,0 +1,7 @@
+# Example settings for the JobSpy service
+
+# Sources allowed by default: indeed, linkedin
+
+# Delay (in seconds) before each scraping request
+JOBSPY_DELAY_SECONDS=1
+

--- a/jobspy/README.md
+++ b/jobspy/README.md
@@ -1,0 +1,15 @@
+# JobSpy Service
+
+Simple FastAPI wrapper around the JobSpy scraping library. Supported job
+sources are currently **Indeed** and **LinkedIn**. Additional sources can be
+added by extending `PERMITTED_SOURCES` in `app/main.py`.
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `JOBSPY_DELAY_SECONDS` | Seconds to wait before making each scraping request. | `1` |
+
+The delay helps avoid triggering provider rate limits. Adjust the value in your
+`.env` file if necessary.
+

--- a/jobspy/__init__.py
+++ b/jobspy/__init__.py
@@ -1,0 +1,2 @@
+# Package marker for JobSpy service
+

--- a/jobspy/app/main.py
+++ b/jobspy/app/main.py
@@ -1,13 +1,41 @@
-from typing import Any
+"""JobSpy FastAPI application."""
 
-from fastapi import FastAPI
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Sequence
+
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 
 
 app = FastAPI(title="JobSpy API", version="0.1.0")
 
 
+# Sources the API is allowed to query. Update this list when enabling new
+# providers.
+PERMITTED_SOURCES: Sequence[str] = ("indeed", "linkedin")
+
+
+def scrape_jobs(source: str) -> dict[str, Any]:
+    """Placeholder for the underlying job scraping implementation."""
+
+    return {"jobs": [], "source": source}
+
+
 @app.get("/jobs/search", response_class=JSONResponse)
-def search_jobs() -> dict[str, Any]:
+def search_jobs(source: str, allowlist: str | None = None) -> dict[str, Any]:
     """Return mock job search results."""
-    return {"jobs": []}
+
+    if source not in PERMITTED_SOURCES:
+        raise HTTPException(status_code=400, detail="source not permitted")
+
+    allowed = {s.strip().lower() for s in allowlist.split(",")} if allowlist else set()
+    if allowed and source.lower() not in allowed:
+        raise HTTPException(status_code=400, detail="source not allowlisted")
+
+    delay = float(os.getenv("JOBSPY_DELAY_SECONDS", "1"))
+    time.sleep(delay)
+    return scrape_jobs(source)
+

--- a/jobspy/tests/test_search.py
+++ b/jobspy/tests/test_search.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import sys
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from jobspy.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_linkedin_allowed_when_allowlisted():
+    response = client.get("/jobs/search", params={"source": "linkedin", "allowlist": "linkedin"})
+    assert response.status_code == 200
+
+
+def test_source_not_allowlisted_rejected():
+    response = client.get("/jobs/search", params={"source": "linkedin", "allowlist": "indeed"})
+    assert response.status_code == 400
+
+
+@patch("jobspy.app.main.scrape_jobs", return_value={"jobs": []})
+@patch("jobspy.app.main.time.sleep")
+def test_delay_before_scrape(mock_sleep, mock_scrape, monkeypatch):
+    monkeypatch.setenv("JOBSPY_DELAY_SECONDS", "2")
+    client.get("/jobs/search", params={"source": "linkedin", "allowlist": "linkedin"})
+    mock_sleep.assert_called_once_with(2.0)
+    mock_scrape.assert_called_once()
+


### PR DESCRIPTION
## Summary
- add LinkedIn to permitted job sources
- support configurable request delay via `JOBSPY_DELAY_SECONDS`
- document sources and env vars for JobSpy service

## Testing
- `python -m py_compile agents/app/*.py`
- `pytest jobspy/tests/test_search.py`


------
https://chatgpt.com/codex/tasks/task_e_68affcd6e4d88330974625a9e9e50995