### PR TITLE
feat(jobspy): cache job search results

### DIFF
--- a/jobspy_service/README.md
+++ b/jobspy_service/README.md
@@ -26,7 +26,9 @@ regardless of the upstream source. Each job contains the following fields:
 | `JOBSPY_SOURCES` | Comma-separated list of allowed providers. | `indeed,linkedin,google` |
 | `JOBSPY_ENABLED` | Toggle scraping feature. | `true` |
 | `JOBSPY_DELAY_SECONDS` | Seconds to wait before making each scraping request. | `2` |
+| `JOBSPY_CACHE_TTL_SECONDS` | Seconds to cache job search results. | `600` |
 
 The delay helps avoid triggering provider rate limits. Adjust the value in your
-`.env` file if necessary.
+`.env` file if necessary. Recent search results are cached in-memory for the
+configured TTL to speed up repeat queries.
 


### PR DESCRIPTION
## Summary
- cache job search results in memory with configurable TTL
- document caching environment variable
- add tests ensuring repeated queries hit cache and TTL expires

## Testing
- `python -m py_compile agents/app/*.py`
- `pytest jobspy_service/tests/test_search.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b005df00f48330864415a916f1cfbc