### PR TITLE
docs: expand AGENT instructions across services

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,10 +1,9 @@
 # AGENT Instructions
 
-This repository contains services for Trainium Career Navigator.
+This repository contains multiple services for Trainium Career Navigator.
 
 - Use conventional commit messages.
-- When Python sources change, run `python -m py_compile agents/app/*.py`.
-- When the Kong configuration is modified, validate it with:
-  `python -c 'import yaml,sys; yaml.safe_load(open("gateway/kong.yml"))'`.
-- The frontend has no automated checks yet.
+- For Python services (agents, backend, jobspy_service), run `python -m py_compile` on changed modules.
+- When the Kong configuration is modified, validate it with `python -c 'import yaml,sys; yaml.safe_load(open("gateway/kong.yml"))'`.
+- The frontend and documentation currently have no automated checks.
 

--- a/backend/AGENT.md
+++ b/backend/AGENT.md
@@ -1,6 +1,5 @@
-# AGENT Instructions for agents service
+# AGENT Instructions for backend
 
 - Target Python 3.11.
 - After modifying code, run `python -m py_compile app/**/*.py`.
 - Keep functions typed and lines under 88 characters.
-

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1,0 +1,5 @@
+# AGENT Instructions for docs
+
+- Use Markdown format.
+- Keep lines under 100 characters.
+- No automated checks are defined.

--- a/frontend/AGENT.md
+++ b/frontend/AGENT.md
@@ -2,5 +2,5 @@
 
 - Static assets live in `public/`.
 - Keep HTML valid and well formatted.
-- No automated checks are defined yet.
+- No automated checks are defined.
 

--- a/gateway/AGENT.md
+++ b/gateway/AGENT.md
@@ -3,3 +3,5 @@
 - Contains Kong declarative configuration.
 - Validate `kong.yml` with `python -c 'import yaml,sys; yaml.safe_load(open("kong.yml"))'`.
 
+- No other automated checks are defined.
+

--- a/jobspy_service/AGENT.md
+++ b/jobspy_service/AGENT.md
@@ -1,0 +1,5 @@
+# AGENT Instructions for jobspy_service
+
+- Target Python 3.11.
+- After modifying code, run `python -m py_compile app/*.py`.
+- Keep functions typed and lines under 88 characters.

--- a/scripts/AGENT.md
+++ b/scripts/AGENT.md
@@ -1,0 +1,4 @@
+# AGENT Instructions for scripts
+
+- Shell scripts should be POSIX-compliant and executable.
+- No automated checks are defined.


### PR DESCRIPTION
## Summary
- extend root AGENT directions to cover all services
- add AGENT guidelines for backend, jobspy service, docs, and scripts
- refresh existing AGENT instructions in agents, frontend, and gateway

## Testing
- `find agents/app backend/app jobspy_service/app -name "*.py" -print0 | xargs -0 python -m py_compile`
- `python -c 'import yaml,sys; yaml.safe_load(open("gateway/kong.yml"))'`


------
https://chatgpt.com/codex/tasks/task_e_68b00c720e74833096719671e45bbe3e