### PR TITLE
feat: add operational metrics logging

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .middleware.metrics import MetricsMiddleware
+from .routes.metrics import router as metrics_router
+from .routes.personas import router as personas_router
+
+
+def create_app() -> FastAPI:
+    """Create and configure a FastAPI application."""
+    app = FastAPI()
+    app.add_middleware(MetricsMiddleware)
+    app.include_router(personas_router)
+    app.include_router(metrics_router)
+    return app

--- a/backend/app/middleware/metrics.py
+++ b/backend/app/middleware/metrics.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+from ..services.metrics import log_metric
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Middleware to log latency and error category for each request."""
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        start = time.perf_counter()
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration_ms = (time.perf_counter() - start) * 1000
+            log_metric(duration_ms, "system")
+            raise
+        duration_ms = (time.perf_counter() - start) * 1000
+        category: Optional[str] = None
+        status = response.status_code
+        if status == 422:
+            category = "model"
+        elif 400 <= status < 500:
+            category = "data"
+        elif status >= 500:
+            category = "system"
+        log_metric(duration_ms, category)
+        return response

--- a/backend/app/models/metric.py
+++ b/backend/app/models/metric.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal, Optional
+
+from pydantic import BaseModel
+
+
+class Metric(BaseModel):
+    """Represents a logged request metric."""
+
+    ts: datetime
+    response_time_ms: float
+    error_category: Optional[Literal["system", "data", "model"]] = None

--- a/backend/app/routes/metrics.py
+++ b/backend/app/routes/metrics.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter
+
+from ..models.metric import Metric
+from ..services.metrics import get_error_rate, get_metrics
+
+router = APIRouter()
+
+
+@router.get("/api/metrics/error_rate")
+def error_rate() -> dict[str, float]:
+    """Return the rolling 7-day error rate."""
+    rate = get_error_rate()
+    return {"error_rate": rate}
+
+
+@router.get("/api/metrics", response_model=List[Metric])
+def list_metrics() -> List[Metric]:
+    """Return recent request metrics."""
+    return get_metrics()

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+import os
+
+import psycopg2
+
+from ..models.metric import Metric
+
+
+def _get_conn() -> psycopg2.extensions.connection:
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL not set")
+    return psycopg2.connect(dsn)
+
+
+def log_metric(response_time_ms: float, error_category: Optional[str] = None) -> None:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO metrics (ts, response_time_ms, error_category)
+            VALUES (%s, %s, %s)
+            """,
+            (datetime.utcnow(), response_time_ms, error_category),
+        )
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+
+
+def get_error_rate(days: int = 7) -> float:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT
+                COUNT(*) FILTER (WHERE error_category IS NOT NULL) AS failures,
+                COUNT(*) AS total
+            FROM metrics
+            WHERE ts >= NOW() - INTERVAL %s
+            """,
+            (f"{days} days",),
+        )
+        failures, total = cur.fetchone()
+        cur.close()
+    finally:
+        conn.close()
+    return 0.0 if total == 0 else failures / total * 100
+
+
+def get_metrics(days: int = 7) -> List[Metric]:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT ts, response_time_ms, error_category
+            FROM metrics
+            WHERE ts >= NOW() - INTERVAL %s
+            ORDER BY ts DESC
+            """,
+            (f"{days} days",),
+        )
+        rows = cur.fetchall()
+        cur.close()
+    finally:
+        conn.close()
+    return [
+        Metric(ts=ts, response_time_ms=rt, error_category=cat)
+        for ts, rt, cat in rows
+    ]

--- a/scripts/migrations/002_create_metrics.sql
+++ b/scripts/migrations/002_create_metrics.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS metrics (
+    id SERIAL PRIMARY KEY,
+    ts TIMESTAMPTZ NOT NULL,
+    response_time_ms DOUBLE PRECISION NOT NULL,
+    error_category VARCHAR(10)
+);


### PR DESCRIPTION
## Summary
- log request metrics to Postgres with latency and error categories
- expose metrics and rolling error rate APIs
- wire middleware into app for automatic tracking
- add SQL migration for metrics table

## Testing
- `python -m py_compile app/**/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b090b057c88330905902406c1aa50a