### PR TITLE
feat: add feedback endpoint

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from .middleware.metrics import MetricsMiddleware
 from .routes.metrics import router as metrics_router
 from .routes.personas import router as personas_router
+from .routes.feedback import router as feedback_router
 
 
 def create_app() -> FastAPI:
@@ -13,4 +14,5 @@ def create_app() -> FastAPI:
     app.add_middleware(MetricsMiddleware)
     app.include_router(personas_router)
     app.include_router(metrics_router)
+    app.include_router(feedback_router)
     return app

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional, Literal
+
+from pydantic import BaseModel
+
+
+class FeedbackIn(BaseModel):
+    """Payload for submitting feedback."""
+
+    job_id: str
+    agent_id: str
+    user_id: str
+    vote: Literal["up", "down"]
+    comment: Optional[str] = None
+
+
+class Feedback(FeedbackIn):
+    """Represents stored feedback."""
+
+    timestamp: datetime

--- a/backend/app/routes/feedback.py
+++ b/backend/app/routes/feedback.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Query
+
+from ..models.feedback import Feedback, FeedbackIn
+from ..services.feedback import list_feedback, save_feedback
+
+router = APIRouter()
+
+
+@router.post("/api/feedback", response_model=Feedback)
+def submit_feedback(feedback: FeedbackIn) -> Feedback:
+    """Store user feedback."""
+    return save_feedback(feedback)
+
+
+@router.get("/api/feedback", response_model=List[Feedback])
+def get_feedback(job_id: Optional[str] = Query(None)) -> List[Feedback]:
+    """Return feedback entries, optionally filtered by job."""
+    return list_feedback(job_id)

--- a/backend/app/services/feedback.py
+++ b/backend/app/services/feedback.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from datetime import datetime
+import os
+
+import psycopg2
+
+from ..models.feedback import Feedback, FeedbackIn
+
+
+def _get_conn() -> psycopg2.extensions.connection:
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL not set")
+    return psycopg2.connect(dsn)
+
+
+def save_feedback(fb: FeedbackIn) -> Feedback:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO feedback (job_id, agent_id, user_id, vote, comment, ts)
+            VALUES (%s, %s, %s, %s, %s, NOW())
+            RETURNING ts
+            """,
+            (
+                fb.job_id,
+                fb.agent_id,
+                fb.user_id,
+                fb.vote == "up",
+                fb.comment,
+            ),
+        )
+        ts = cur.fetchone()[0]
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+    return Feedback(timestamp=ts, **fb.dict())
+
+
+def list_feedback(job_id: Optional[str] = None) -> List[Feedback]:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        if job_id:
+            cur.execute(
+                """
+                SELECT job_id, agent_id, user_id, vote, comment, ts
+                FROM feedback
+                WHERE job_id = %s
+                ORDER BY ts DESC
+                """,
+                (job_id,),
+            )
+        else:
+            cur.execute(
+                """
+                SELECT job_id, agent_id, user_id, vote, comment, ts
+                FROM feedback
+                ORDER BY ts DESC
+                """
+            )
+        rows = cur.fetchall()
+        cur.close()
+    finally:
+        conn.close()
+    results: List[Feedback] = []
+    for j, a, u, v, c, ts in rows:
+        vote = "up" if v else "down"
+        results.append(
+            Feedback(
+                job_id=j,
+                agent_id=a,
+                user_id=u,
+                vote=vote,
+                comment=c,
+                timestamp=ts,
+            )
+        )
+    return results

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app.models.feedback import Feedback
+from backend.app.routes.feedback import router
+
+
+def test_feedback_endpoints(monkeypatch) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    now = datetime.utcnow()
+    sample = Feedback(
+        job_id="job1",
+        agent_id="agentA",
+        user_id="userX",
+        vote="up",
+        comment="nice",
+        timestamp=now,
+    )
+
+    def fake_save(feedback):
+        assert feedback.job_id == "job1"
+        return sample
+
+    def fake_list(job_id=None):
+        assert job_id == "job1"
+        return [sample]
+
+    monkeypatch.setattr("backend.app.routes.feedback.save_feedback", fake_save)
+    monkeypatch.setattr("backend.app.routes.feedback.list_feedback", fake_list)
+
+    resp = client.post(
+        "/api/feedback",
+        json={
+            "job_id": "job1",
+            "agent_id": "agentA",
+            "user_id": "userX",
+            "vote": "up",
+            "comment": "nice",
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["job_id"] == "job1"
+
+    resp2 = client.get("/api/feedback", params={"job_id": "job1"})
+    assert resp2.status_code == 200
+    items = resp2.json()
+    assert len(items) == 1
+    assert items[0]["vote"] == "up"


### PR DESCRIPTION
## Summary
- add feedback model and service to persist up/down votes
- expose `/api/feedback` POST and GET routes
- cover feedback API with unit test

## Testing
- `python -m py_compile backend/app/**/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0933a1eec8330b3d4d58d4da72b4b