### PR TITLE
feat: track user metrics

### DIFF
--- a/backend/app/models/surfaced_job.py
+++ b/backend/app/models/surfaced_job.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SurfacedJobIn(BaseModel):
+    """Payload for logging a surfaced job."""
+
+    job_id: str
+    agent_id: str
+    user_id: str

--- a/backend/app/routes/metrics.py
+++ b/backend/app/routes/metrics.py
@@ -5,7 +5,14 @@ from typing import List
 from fastapi import APIRouter
 
 from ..models.metric import Metric
-from ..services.metrics import get_error_rate, get_metrics
+from ..models.surfaced_job import SurfacedJobIn
+from ..services.metrics import (
+    count_false_positives,
+    get_error_rate,
+    get_fit_accuracy,
+    get_metrics,
+    log_surfaced_job,
+)
 
 router = APIRouter()
 
@@ -21,3 +28,24 @@ def error_rate() -> dict[str, float]:
 def list_metrics() -> List[Metric]:
     """Return recent request metrics."""
     return get_metrics()
+
+
+@router.post("/api/metrics/surfaced_job")
+def surfaced_job(payload: SurfacedJobIn) -> dict[str, str]:
+    """Log when a job is surfaced to a user."""
+    log_surfaced_job(payload.job_id, payload.user_id, payload.agent_id)
+    return {"status": "ok"}
+
+
+@router.get("/api/metrics/fit_accuracy")
+def fit_accuracy() -> dict[str, float]:
+    """Return the rolling 7-day fit accuracy."""
+    acc = get_fit_accuracy()
+    return {"fit_accuracy": acc}
+
+
+@router.get("/api/metrics/false_positives")
+def false_positives() -> dict[str, int]:
+    """Return the count of recent false positives."""
+    count = count_false_positives()
+    return {"false_positives": count}

--- a/backend/app/services/feedback.py
+++ b/backend/app/services/feedback.py
@@ -8,6 +8,7 @@ import os
 import psycopg2
 
 from ..models.feedback import Feedback, FeedbackIn
+from .metrics import log_surfaced_job
 
 
 def _get_conn() -> psycopg2.extensions.connection:
@@ -18,6 +19,7 @@ def _get_conn() -> psycopg2.extensions.connection:
 
 
 def save_feedback(fb: FeedbackIn) -> Feedback:
+    log_surfaced_job(fb.job_id, fb.user_id, fb.agent_id)
     conn = _get_conn()
     try:
         cur = conn.cursor()

--- a/backend/app/services/metrics.py
+++ b/backend/app/services/metrics.py
@@ -76,3 +76,66 @@ def get_metrics(days: int = 7) -> List[Metric]:
         Metric(ts=ts, response_time_ms=rt, error_category=cat)
         for ts, rt, cat in rows
     ]
+
+
+def log_surfaced_job(job_id: str, user_id: str, agent_id: str) -> None:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO surfaced_jobs (job_id, user_id, agent_id, ts)
+            VALUES (%s, %s, %s, NOW())
+            """,
+            (job_id, user_id, agent_id),
+        )
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+
+
+def get_fit_accuracy(days: int = 7) -> float:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT
+                SUM(CASE WHEN vote THEN 1 ELSE 0 END) AS positives,
+                COUNT(*) AS total
+            FROM feedback
+            WHERE ts >= NOW() - INTERVAL %s
+            """,
+            (f"{days} days",),
+        )
+        positives, total = cur.fetchone()
+        cur.close()
+    finally:
+        conn.close()
+    return 0.0 if total == 0 else positives / total
+
+
+def count_false_positives(days: int = 7) -> int:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT COUNT(*)
+            FROM surfaced_jobs sj
+            LEFT JOIN feedback f ON (
+                sj.job_id = f.job_id AND
+                sj.user_id = f.user_id AND
+                sj.agent_id = f.agent_id
+            )
+            WHERE sj.ts >= NOW() - INTERVAL %s
+              AND (f.vote = FALSE OR f.job_id IS NULL)
+            """,
+            (f"{days} days",),
+        )
+        count = cur.fetchone()[0]
+        cur.close()
+    finally:
+        conn.close()
+    return count

--- a/docs/missed_opportunities.md
+++ b/docs/missed_opportunities.md
@@ -1,0 +1,14 @@
+# Missed Opportunities Design
+
+Missed Opportunities capture jobs a user applies to that Trainium did not surface.
+This helps identify gaps in scraping, ranking, or filtering.
+
+## Data Capture
+- Record jobs the user applied to outside Trainium with job URL and metadata.
+- Compare against surfaced jobs to detect gaps.
+- Store all scraped jobs, including those rejected by the AI, for review.
+
+## Future Workflow
+1. User reports an external application.
+2. System checks if the job was scraped but filtered out.
+3. Analysts review AI-rejected listings to improve recall.


### PR DESCRIPTION
## Summary
- log surfaced jobs and compute fit accuracy and false positives
- expose new metrics endpoints and log surfaced jobs when feedback is submitted
- document missed opportunities tracking for future analysis

## Testing
- `python -m py_compile app/models/surfaced_job.py app/services/metrics.py app/routes/metrics.py app/services/feedback.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b094d283388330b6e4ad21725440f4