### PR TITLE
feat: capture application conversion metrics

### DIFF
--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ApplicationIn(BaseModel):
+    """Payload for logging a job application."""
+
+    job_id: str
+    agent_id: str
+    user_id: str

--- a/backend/app/routes/metrics.py
+++ b/backend/app/routes/metrics.py
@@ -4,6 +4,7 @@ from typing import List
 
 from fastapi import APIRouter
 
+from ..models.application import ApplicationIn
 from ..models.metric import Metric
 from ..models.surfaced_job import SurfacedJobIn
 from ..services.metrics import (
@@ -11,7 +12,9 @@ from ..services.metrics import (
     get_error_rate,
     get_fit_accuracy,
     get_metrics,
+    get_application_conversion,
     log_surfaced_job,
+    log_application,
 )
 
 router = APIRouter()
@@ -37,6 +40,13 @@ def surfaced_job(payload: SurfacedJobIn) -> dict[str, str]:
     return {"status": "ok"}
 
 
+@router.post("/api/metrics/application")
+def application(payload: ApplicationIn) -> dict[str, str]:
+    """Log when a user applies to a surfaced job."""
+    log_application(payload.job_id, payload.user_id, payload.agent_id)
+    return {"status": "ok"}
+
+
 @router.get("/api/metrics/fit_accuracy")
 def fit_accuracy() -> dict[str, float]:
     """Return the rolling 7-day fit accuracy."""
@@ -49,3 +59,10 @@ def false_positives() -> dict[str, int]:
     """Return the count of recent false positives."""
     count = count_false_positives()
     return {"false_positives": count}
+
+
+@router.get("/api/metrics/application_conversion")
+def application_conversion() -> dict[str, float | int]:
+    """Return recent application conversion metrics."""
+    rate, volume = get_application_conversion()
+    return {"application_rate": rate, "application_volume": volume}


### PR DESCRIPTION
## Summary
- add ApplicationIn model for logging job applications
- track application counts and compute conversion rate for surfaced jobs
- expose API endpoints for application logging and conversion retrieval

## Testing
- `python -m py_compile app/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68b09799d6448330965f6399ae3e0849