### PR TITLE
feat: parameterize service ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,12 @@ MONGO_DB=trainium
 KONG_LOG_LEVEL=info
 # Admin API bound to localhost by default; change to 0.0.0.0:8001 for host access in dev
 KONG_ADMIN_LISTEN=127.0.0.1:8001
+KONG_PROXY_PORT=8000
+KONG_ADMIN_PORT=8001
 
 # === App ===
 ENVIRONMENT=local
+FRONTEND_PORT=80
 
 # === JobSpy ===
 JOBSPY_DELAY_SECONDS=2

--- a/README.md
+++ b/README.md
@@ -36,9 +36,12 @@ MONGO_DB=trainium
 KONG_LOG_LEVEL=info
 # Admin API bound to localhost; change to 0.0.0.0:8001 for host access in dev
 KONG_ADMIN_LISTEN=127.0.0.1:8001
+KONG_PROXY_PORT=8000
+KONG_ADMIN_PORT=8001
 
 # === App ===
 ENVIRONMENT=local
+FRONTEND_PORT=80
 ```
 
 > **Tip**: Keep a private `.env.local` for real secrets and `source` it in your shell before running Docker.
@@ -49,6 +52,8 @@ ENVIRONMENT=local
 - **MONGO_HOST / MONGO_PORT / MONGO_DB**: Connection settings for the Mongo container.
 - **KONG_LOG_LEVEL**: Kong log verbosity (`info`, `debug`, etc.).
 - **KONG_ADMIN_LISTEN**: Admin API bind. Defaults to `127.0.0.1:8001` for safety; set to `0.0.0.0:8001` if you need host access in development.
+- **KONG_PROXY_PORT / KONG_ADMIN_PORT**: Host ports for Kong's proxy and admin interfaces.
+- **FRONTEND_PORT**: Port exposed for the frontend service.
 - **ENVIRONMENT**: Passed to the Agents service for environment-aware behavior.
 
 An **`.env.example`** is checked in with safe placeholders so others can copy it to `.env` quickly.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,15 +24,15 @@ services:
     volumes:
       - ./gateway/kong.yml:/etc/kong/kong.yml:ro
     ports:
-      - "8000:8000"   # public proxy
-      - "8001:8001"   # admin api (dev only)
+      - "${KONG_PROXY_PORT}:8000"   # public proxy
+      - "${KONG_ADMIN_PORT}:8001"   # admin api (dev only)
     networks: [trainium-net]
     restart: unless-stopped
 
   frontend:
     build: ./frontend
-    expose:
-      - "80"
+    ports:
+      - "${FRONTEND_PORT}:80"
     networks: [trainium-net]
     restart: unless-stopped
 
@@ -84,7 +84,7 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     ports:
-      - "5432:5432"      # expose for local tools (optional)
+      - "${POSTGRES_PORT}:5432"      # expose for local tools (optional)
     networks: [trainium-net]
     restart: unless-stopped
     healthcheck:
@@ -102,7 +102,7 @@ services:
     volumes:
       - mongodata:/data/db
     ports:
-      - "27017:27017"    # expose for local tools (optional)
+      - "${MONGO_PORT}:27017"    # expose for local tools (optional)
     networks: [trainium-net]
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
## Summary
- add KONG_PROXY_PORT, KONG_ADMIN_PORT, and FRONTEND_PORT defaults
- map service host ports to env vars in docker-compose
- document new port variables in README

## Testing
- `docker compose --env-file .env.example config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b09d99e2c883309dc8bdb9c7481549