### PR TITLE
ci: rename smoke test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Smoke Tests
+name: CI
 
 on:
   push:
@@ -11,7 +11,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Copy env
         run: cp .env.example .env
-      - name: Build and run stack
+      - name: Build images
+        run: docker compose build
+      - name: Start stack
         run: docker compose up -d --build
       - name: Wait for services
         run: |
@@ -23,7 +25,7 @@ jobs:
           done
           exit 1
       - name: Run smoke tests
-        run: ./scripts/smoke_test.sh
+        run: scripts/smoke_test.sh
       - name: Tear down
         if: always()
         run: docker compose down -v


### PR DESCRIPTION
## Summary
- rename smoke-tests workflow to ci
- add image build and stack startup steps to CI workflow

## Testing
- `python - <<'PY'
import yaml, sys, pathlib
pathlib.Path('.github/workflows/ci.yml').read_text()
yaml.safe_load(open('.github/workflows/ci.yml'))
print('YAML OK')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b09e52aa848330b39d1fce986808f0