### PR TITLE
feat: persist normalized jobs

### DIFF
--- a/jobspy_service/requirements.txt
+++ b/jobspy_service/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.116.1
 uvicorn==0.35.0
 httpx==0.28.1
+psycopg2-binary==2.9.10

--- a/scripts/migrations/003_create_jobs_normalized.sql
+++ b/scripts/migrations/003_create_jobs_normalized.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS jobs_normalized (
+    id SERIAL PRIMARY KEY,
+    source TEXT NOT NULL,
+    title TEXT NOT NULL,
+    company TEXT,
+    description TEXT,
+    location TEXT,
+    url TEXT,
+    is_remote BOOLEAN,
+    job_id_ext TEXT NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (source, job_id_ext)
+);


### PR DESCRIPTION
## Summary
- ingest board jobs via JobSpy with board-specific config
- normalize fields and upsert into `jobs_normalized`
- add migration for `jobs_normalized` table

## Testing
- `python -m py_compile jobspy_service/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0b1b8c1488330a8a4705c168bb149