### PR TITLE
feat: add semantic job deduplication

### DIFF
--- a/jobspy_service/app/dedupe.py
+++ b/jobspy_service/app/dedupe.py
@@ -1,0 +1,40 @@
+"""Helpers for deduplicating job postings using semantic similarity."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+
+_MODEL = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+
+
+def _embed(job: dict) -> np.ndarray:
+    """Return a normalized embedding for the job title and description."""
+
+    text = " ".join(
+        part for part in (job.get("title"), job.get("description")) if part
+    )
+    return _MODEL.encode(text, normalize_embeddings=True)
+
+
+def _cosine(a: np.ndarray, b: np.ndarray) -> float:
+    """Cosine similarity for normalized vectors."""
+
+    return float(np.dot(a, b))
+
+
+def dedupe_jobs(jobs: Sequence[dict], *, threshold: float = 0.85) -> list[dict]:
+    """Remove semantically similar job postings."""
+
+    kept: list[dict] = []
+    embeddings: list[np.ndarray] = []
+    for job in jobs:
+        emb = _embed(job)
+        if all(_cosine(emb, existing) < threshold for existing in embeddings):
+            kept.append(job)
+            embeddings.append(emb)
+    return kept
+

--- a/jobspy_service/requirements.txt
+++ b/jobspy_service/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.116.1
 uvicorn==0.35.0
 httpx==0.28.1
 psycopg2-binary==2.9.10
+sentence-transformers==2.2.2

--- a/jobspy_service/tests/test_dedupe.py
+++ b/jobspy_service/tests/test_dedupe.py
@@ -1,0 +1,24 @@
+from jobspy_service.app.dedupe import dedupe_jobs
+
+
+def test_semantic_duplicates_merge() -> None:
+    jobs = [
+        {
+            "title": "Python Developer",
+            "description": "Build backend APIs",
+        },
+        {
+            "title": "Backend Engineer",
+            "description": "Develop APIs using Python",
+        },
+        {
+            "title": "Graphic Designer",
+            "description": "Create visual assets",
+        },
+    ]
+    deduped = dedupe_jobs(jobs)
+    assert len(deduped) == 2
+    titles = {j["title"] for j in deduped}
+    assert "Graphic Designer" in titles
+    assert ("Python Developer" in titles) ^ ("Backend Engineer" in titles)
+


### PR DESCRIPTION
## Summary
- add sentence-transformers dependency
- implement semantic job deduplication using sentence embeddings
- cover dedupe logic with tests

## Testing
- `python -m py_compile app/*.py`
- `pytest tests/test_dedupe.py -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*


------
https://chatgpt.com/codex/tasks/task_e_68b1ec181a648330bf686733ef3cd63d