### PR TITLE
feat: queue dedupe reviews for admin approval

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -6,6 +6,7 @@ from .middleware.metrics import MetricsMiddleware
 from .routes.metrics import router as metrics_router
 from .routes.personas import router as personas_router
 from .routes.feedback import router as feedback_router
+from .routes.dedupe import router as dedupe_router
 
 
 def create_app() -> FastAPI:
@@ -15,4 +16,5 @@ def create_app() -> FastAPI:
     app.include_router(personas_router)
     app.include_router(metrics_router)
     app.include_router(feedback_router)
+    app.include_router(dedupe_router)
     return app

--- a/backend/app/models/dedupe_review.py
+++ b/backend/app/models/dedupe_review.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class DedupeReview(BaseModel):
+    """Record of a dedupe candidate pair."""
+
+    id: int
+    job_id_1: int
+    job_id_2: int
+    similarity: float
+    status: str
+    created_at: datetime
+    reviewed_at: datetime | None = None

--- a/backend/app/routes/dedupe.py
+++ b/backend/app/routes/dedupe.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter
+
+from ..models.dedupe_review import DedupeReview
+from ..services.dedupe import list_pending, record_decision
+
+router = APIRouter()
+
+
+@router.get("/api/dedupe/review", response_model=List[DedupeReview])
+def list_reviews() -> List[DedupeReview]:
+    """Return dedupe pairs awaiting review."""
+    return list_pending()
+
+
+@router.post("/api/dedupe/review/{review_id}/approve")
+def approve_review(review_id: int) -> dict[str, str]:
+    """Approve a dedupe pair."""
+    record_decision(review_id, "approved")
+    return {"status": "ok"}
+
+
+@router.post("/api/dedupe/review/{review_id}/reject")
+def reject_review(review_id: int) -> dict[str, str]:
+    """Reject a dedupe pair."""
+    record_decision(review_id, "rejected")
+    return {"status": "ok"}
+

--- a/backend/app/services/dedupe.py
+++ b/backend/app/services/dedupe.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import List
+import os
+import psycopg2
+
+from ..models.dedupe_review import DedupeReview
+
+AUTO_THRESHOLD = float(os.getenv("DEDUPE_AUTO_THRESHOLD", "0.95"))
+REVIEW_THRESHOLD = float(os.getenv("DEDUPE_REVIEW_THRESHOLD", "0.8"))
+
+
+def _get_conn() -> psycopg2.extensions.connection:
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL not set")
+    return psycopg2.connect(dsn)
+
+
+def enqueue_review(job_id_1: int, job_id_2: int, similarity: float) -> None:
+    if job_id_1 > job_id_2:
+        job_id_1, job_id_2 = job_id_2, job_id_1
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO dedupe_review (job_id_1, job_id_2, similarity, status)
+            VALUES (%s, %s, %s, 'pending')
+            ON CONFLICT (job_id_1, job_id_2) DO UPDATE SET
+                similarity = EXCLUDED.similarity,
+                status = 'pending',
+                reviewed_at = NULL
+            """,
+            (job_id_1, job_id_2, similarity),
+        )
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+
+
+def list_pending() -> List[DedupeReview]:
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT id, job_id_1, job_id_2, similarity, status, created_at, reviewed_at
+            FROM dedupe_review
+            WHERE status = 'pending'
+            ORDER BY created_at
+            """,
+        )
+        rows = cur.fetchall()
+        cur.close()
+    finally:
+        conn.close()
+    return [
+        DedupeReview(
+            id=r[0],
+            job_id_1=r[1],
+            job_id_2=r[2],
+            similarity=r[3],
+            status=r[4],
+            created_at=r[5],
+            reviewed_at=r[6],
+        )
+        for r in rows
+    ]
+
+
+def record_decision(review_id: int, decision: str) -> None:
+    if decision not in {"approved", "rejected"}:
+        raise ValueError("invalid decision")
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            UPDATE dedupe_review
+            SET status = %s, reviewed_at = NOW()
+            WHERE id = %s
+            """,
+            (decision, review_id),
+        )
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+
+
+def should_merge(job_id_1: int, job_id_2: int, similarity: float) -> bool:
+    if job_id_1 > job_id_2:
+        job_id_1, job_id_2 = job_id_2, job_id_1
+    conn = _get_conn()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT status FROM dedupe_review
+            WHERE job_id_1 = %s AND job_id_2 = %s
+            """,
+            (job_id_1, job_id_2),
+        )
+        row = cur.fetchone()
+        cur.close()
+    finally:
+        conn.close()
+    if row:
+        status = row[0]
+        return status == 'approved'
+    if similarity >= AUTO_THRESHOLD:
+        return True
+    if similarity >= REVIEW_THRESHOLD:
+        enqueue_review(job_id_1, job_id_2, similarity)
+    return False

--- a/backend/tests/test_dedupe.py
+++ b/backend/tests/test_dedupe.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app.models.dedupe_review import DedupeReview
+from backend.app.routes.dedupe import router
+
+
+def test_dedupe_review_endpoints(monkeypatch) -> None:
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    sample = DedupeReview(
+        id=1,
+        job_id_1=1,
+        job_id_2=2,
+        similarity=0.83,
+        status="pending",
+        created_at=datetime.utcnow(),
+        reviewed_at=None,
+    )
+
+    def fake_list() -> list[DedupeReview]:
+        return [sample]
+
+    def fake_record(review_id: int, decision: str) -> None:
+        assert review_id == 1
+        assert decision in {"approved", "rejected"}
+
+    monkeypatch.setattr("backend.app.routes.dedupe.list_pending", fake_list)
+    monkeypatch.setattr("backend.app.routes.dedupe.record_decision", fake_record)
+
+    resp = client.get("/api/dedupe/review")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert items[0]["id"] == 1
+
+    resp2 = client.post("/api/dedupe/review/1/approve")
+    assert resp2.status_code == 200
+
+    resp3 = client.post("/api/dedupe/review/1/reject")
+    assert resp3.status_code == 200

--- a/scripts/dedupe_jobs.py
+++ b/scripts/dedupe_jobs.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+from backend.app.services.dedupe import should_merge
+
+
+def dedupe_jobs(pairs: Iterable[Tuple[int, int, float]]) -> List[Tuple[int, int]]:
+    """Return pairs that should be merged.
+
+    Borderline pairs are queued for manual review and excluded from the result
+    until a human decision is recorded.
+    """
+
+    merged: List[Tuple[int, int]] = []
+    for job_a, job_b, similarity in pairs:
+        if should_merge(job_a, job_b, similarity):
+            merged.append((job_a, job_b))
+    return merged

--- a/scripts/migrations/004_create_dedupe_review.sql
+++ b/scripts/migrations/004_create_dedupe_review.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS dedupe_review (
+    id SERIAL PRIMARY KEY,
+    job_id_1 INT NOT NULL REFERENCES jobs_normalized(id) ON DELETE CASCADE,
+    job_id_2 INT NOT NULL REFERENCES jobs_normalized(id) ON DELETE CASCADE,
+    similarity DOUBLE PRECISION NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    reviewed_at TIMESTAMPTZ,
+    CONSTRAINT dedupe_review_job_pair_unique UNIQUE (job_id_1, job_id_2)
+);


### PR DESCRIPTION
## Summary
- add dedupe_review table to track pending job pairs
- expose admin endpoints to list, approve or reject dedupe candidates
- enqueue borderline matches for manual review instead of merging immediately

## Testing
- `python -m py_compile backend/app/__init__.py backend/app/models/dedupe_review.py backend/app/routes/dedupe.py backend/app/services/dedupe.py scripts/dedupe_jobs.py backend/tests/test_dedupe.py`
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b1f2ba8c2c8330bf8252a80fb27399