### PR TITLE
feat: aggregate persona decisions and expose recommendations

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -8,6 +8,7 @@ from .routes.personas import router as personas_router
 from .routes.feedback import router as feedback_router
 from .routes.dedupe import router as dedupe_router
 from .routes.evaluate import router as evaluate_router
+from .routes.recommendations import router as recommendations_router
 
 
 def create_app() -> FastAPI:
@@ -19,4 +20,5 @@ def create_app() -> FastAPI:
     app.include_router(feedback_router)
     app.include_router(dedupe_router)
     app.include_router(evaluate_router)
+    app.include_router(recommendations_router)
     return app

--- a/backend/app/models/decision.py
+++ b/backend/app/models/decision.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class Decision(BaseModel):
+    """Final decision for a job after aggregation."""
+
+    job_id: str
+    final_decision_bool: bool
+    confidence: float
+    method: str

--- a/backend/app/models/recommendation.py
+++ b/backend/app/models/recommendation.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class Recommendation(BaseModel):
+    """Job recommendation derived from final decisions."""
+
+    job_id: str
+    title: str | None
+    company: str | None
+    url: str | None
+    rationale: str | None
+    confidence: float

--- a/backend/app/routes/recommendations.py
+++ b/backend/app/routes/recommendations.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter
+
+from ..models.recommendation import Recommendation
+from ..services.recommendations import list_recommendations
+
+router = APIRouter()
+
+
+@router.get("/api/recommendations", response_model=List[Recommendation])
+def recommendations() -> List[Recommendation]:
+    """List jobs with a positive final decision."""
+    return list_recommendations()

--- a/backend/app/services/decisions.py
+++ b/backend/app/services/decisions.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+
+from .evaluation import (
+    DECISION_PERSONAS,
+    _get_conn,
+    evaluate_decision_personas,
+)
+from ..models.decision import Decision
+
+logger = logging.getLogger(__name__)
+
+
+def aggregate_decision(job_id: str) -> Decision:
+    """Use the Judge persona to record the final decision for a job."""
+    evaluate_decision_personas(job_id)
+    conn = _get_conn()
+    final = False
+    confidence = 0.0
+    method = "judge"
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT vote_bool, rationale_text FROM evaluations "
+            "WHERE job_unique_id = %s AND persona = %s",
+            (job_id, "judge"),
+        )
+        row = cur.fetchone()
+        if row:
+            final = bool(row[0])
+        personas = [p for p in DECISION_PERSONAS if p != "judge"]
+        placeholders = ",".join(["%s"] * len(personas))
+        cur.execute(
+            f"SELECT vote_bool FROM evaluations WHERE job_unique_id = %s "
+            f"AND persona IN ({placeholders})",
+            [job_id, *personas],
+        )
+        votes = cur.fetchall()
+        yes = sum(1 for (vote,) in votes if vote)
+        no = sum(1 for (vote,) in votes if not vote)
+        total = yes + no
+        confidence = (max(yes, no) / total) if total else 0.0
+        cur.execute(
+            """
+            INSERT INTO decisions (
+                job_unique_id, final_decision_bool, confidence, method, created_at
+            ) VALUES (%s, %s, %s, %s, NOW())
+            ON CONFLICT (job_unique_id) DO UPDATE SET
+                final_decision_bool = EXCLUDED.final_decision_bool,
+                confidence = EXCLUDED.confidence,
+                method = EXCLUDED.method,
+                created_at = EXCLUDED.created_at
+            """,
+            (job_id, final, confidence, method),
+        )
+        conn.commit()
+        cur.close()
+    finally:
+        conn.close()
+    return Decision(
+        job_id=job_id,
+        final_decision_bool=final,
+        confidence=confidence,
+        method=method,
+    )

--- a/backend/app/services/evaluation.py
+++ b/backend/app/services/evaluation.py
@@ -22,6 +22,13 @@ MOTIVATIONAL_PERSONAS = [
     "adventurer",
 ]
 
+DECISION_PERSONAS = [
+    "visionary",
+    "realist",
+    "guardian",
+    "judge",
+]
+
 
 class PersonaLLM(BaseLLM):
     """Deterministic LLM used for persona simulations."""
@@ -82,13 +89,13 @@ def _parse_output(raw: str) -> Tuple[bool, str]:
     return vote, rationale
 
 
-def evaluate_job(job_id: str) -> List[PersonaEvaluation]:
+def _evaluate_persona_set(job_id: str, persona_ids: List[str]) -> List[PersonaEvaluation]:
     conn = _get_conn()
     results: List[PersonaEvaluation] = []
     agents = _build_agents(job_id)
     try:
         cur = conn.cursor()
-        for persona_id in MOTIVATIONAL_PERSONAS:
+        for persona_id in persona_ids:
             task = Task(
                 description=(
                     "Consult other personas in the crew and evaluate the job. "
@@ -127,3 +134,11 @@ def evaluate_job(job_id: str) -> List[PersonaEvaluation]:
     finally:
         conn.close()
     return results
+
+
+def evaluate_job(job_id: str) -> List[PersonaEvaluation]:
+    return _evaluate_persona_set(job_id, MOTIVATIONAL_PERSONAS)
+
+
+def evaluate_decision_personas(job_id: str) -> List[PersonaEvaluation]:
+    return _evaluate_persona_set(job_id, DECISION_PERSONAS)

--- a/backend/app/services/recommendations.py
+++ b/backend/app/services/recommendations.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import List
+
+from .evaluation import _get_conn
+from ..models.recommendation import Recommendation
+
+
+def list_recommendations() -> List[Recommendation]:
+    """Return recommended jobs with positive final decisions."""
+    conn = _get_conn()
+    results: List[Recommendation] = []
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT job_unique_id, confidence FROM decisions "
+            "WHERE final_decision_bool = TRUE"
+        )
+        decisions = cur.fetchall()
+        for job_id, confidence in decisions:
+            cur.execute(
+                "SELECT title, company, url FROM jobs_normalized "
+                "WHERE job_id_ext = %s",
+                (job_id,),
+            )
+            job_row = cur.fetchone()
+            title, company, url = job_row if job_row else (None, None, None)
+            cur.execute(
+                "SELECT rationale_text FROM evaluations "
+                "WHERE job_unique_id = %s AND persona = %s",
+                (job_id, "judge"),
+            )
+            rationale_row = cur.fetchone()
+            rationale = rationale_row[0] if rationale_row else None
+            results.append(
+                Recommendation(
+                    job_id=job_id,
+                    title=title,
+                    company=company,
+                    url=url,
+                    rationale=rationale,
+                    confidence=confidence,
+                )
+            )
+        cur.close()
+    finally:
+        conn.close()
+    return results

--- a/backend/tests/test_decisions.py
+++ b/backend/tests/test_decisions.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app.services import decisions as decisions_service
+from backend.app.models.decision import Decision
+
+
+
+class FakeCursor:
+    def __init__(self, judge_row, other_rows):
+        self.judge_row = judge_row
+        self.other_rows = other_rows
+        self.calls = []
+        self.last_query = ""
+
+    def execute(self, query: str, params: tuple | list | None = None) -> None:
+        self.calls.append((query, params))
+        self.last_query = query
+
+    def fetchone(self):
+        if "persona = %s" in self.last_query:
+            return self.judge_row
+        return None
+
+    def fetchall(self):
+        if "persona IN" in self.last_query:
+            return self.other_rows
+        return []
+
+    def close(self) -> None:
+        pass
+
+
+class FakeConn:
+    def __init__(self, judge_row, other_rows):
+        self.cursor_obj = FakeCursor(judge_row, other_rows)
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def test_aggregate_decision(monkeypatch) -> None:
+    judge_row = (True, "judge yes")
+    other_rows = [(True,), (False,), (True,)]
+    fake = FakeConn(judge_row, other_rows)
+    monkeypatch.setattr(decisions_service, "_get_conn", lambda: fake)
+    monkeypatch.setattr(
+        decisions_service, "evaluate_decision_personas", lambda job_id: []
+    )
+    result = decisions_service.aggregate_decision("job1")
+    assert isinstance(result, Decision)
+    assert result.final_decision_bool is True
+    assert abs(result.confidence - 2 / 3) < 1e-6
+    insert_calls = [c for c in fake.cursor_obj.calls if "INSERT INTO decisions" in c[0]]
+    assert insert_calls
+    judge_calls = [c for c in fake.cursor_obj.calls if "persona = %s" in c[0]]
+    assert judge_calls

--- a/backend/tests/test_evaluation_service.py
+++ b/backend/tests/test_evaluation_service.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
 from backend.app.services import evaluation as evaluation_service
 from backend.app.models.evaluation import PersonaEvaluation
 
@@ -34,3 +39,11 @@ def test_evaluate_job_crewai(monkeypatch) -> None:
     assert all(isinstance(r, PersonaEvaluation) for r in results)
     personas = {r.persona for r in results}
     assert personas == set(evaluation_service.MOTIVATIONAL_PERSONAS)
+
+
+def test_evaluate_decision_personas(monkeypatch) -> None:
+    monkeypatch.setattr(evaluation_service, "_get_conn", lambda: FakeConn())
+    results = evaluation_service.evaluate_decision_personas("job2")
+    assert len(results) == 4
+    personas = {r.persona for r in results}
+    assert personas == set(evaluation_service.DECISION_PERSONAS)

--- a/backend/tests/test_recommendations.py
+++ b/backend/tests/test_recommendations.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app.services import recommendations as rec_service
+from backend.app.models.recommendation import Recommendation
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class FakeCursor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple | None]] = []
+        self.last_query = ""
+
+    def execute(self, query: str, params: tuple | None = None) -> None:
+        self.calls.append((query, params))
+        self.last_query = query
+
+    def fetchall(self):
+        if "FROM decisions" in self.last_query:
+            return [("job1", 0.75)]
+        return []
+
+    def fetchone(self):
+        if "FROM jobs_normalized" in self.last_query:
+            return ("Engineer", "Acme", "http://a")
+        if "FROM evaluations" in self.last_query:
+            return ("Great role",)
+        return None
+
+    def close(self) -> None:  # pragma: no cover - no action
+        pass
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.cursor_obj = FakeCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self) -> None:  # pragma: no cover - no action
+        pass
+
+    def close(self) -> None:  # pragma: no cover - no action
+        pass
+
+
+def test_list_recommendations(monkeypatch) -> None:
+    fake = FakeConn()
+    monkeypatch.setattr(rec_service, "_get_conn", lambda: fake)
+    recs = rec_service.list_recommendations()
+    assert len(recs) == 1
+    rec = recs[0]
+    assert isinstance(rec, Recommendation)
+    assert rec.job_id == "job1"
+    assert rec.title == "Engineer"
+    assert rec.company == "Acme"
+    assert rec.url == "http://a"
+    assert rec.rationale == "Great role"
+    assert rec.confidence == 0.75
+    eval_calls = [
+        c for c in fake.cursor_obj.calls if "FROM evaluations" in c[0]
+    ]
+    assert eval_calls and "persona = %s" in eval_calls[0][0]
+
+
+def test_api_recommendations(monkeypatch) -> None:
+    app = FastAPI()
+    from backend.app.routes import recommendations as route_module
+
+    monkeypatch.setattr(
+        route_module,
+        "list_recommendations",
+        lambda: [
+            Recommendation(
+                job_id="job1",
+                title="Engineer",
+                company="Acme",
+                url="http://a",
+                rationale="Great role",
+                confidence=0.75,
+            )
+        ],
+    )
+    app.include_router(route_module.router)
+    client = TestClient(app)
+    resp = client.get("/api/recommendations")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["job_id"] == "job1"

--- a/scripts/migrations/006_create_decisions.sql
+++ b/scripts/migrations/006_create_decisions.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS decisions (
+    id SERIAL PRIMARY KEY,
+    job_unique_id TEXT NOT NULL UNIQUE,
+    final_decision_bool BOOLEAN NOT NULL,
+    confidence REAL NOT NULL,
+    method TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add DECISION_PERSONAS evaluation and judge aggregation
- store final decisions and surface recommendations API
- create migrations and tests for decision workflow
- ensure judge persona determines final decisions and recommendation rationale

## Testing
- `python -m py_compile app/**/*.py`
- `pytest tests/test_evaluation_service.py tests/test_decisions.py tests/test_recommendations.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1fe604e2083309d483b2b6ff97c98