### PR TITLE
feat(backend): add user filter to feedback retrieval

### DIFF
--- a/backend/app/routes/feedback.py
+++ b/backend/app/routes/feedback.py
@@ -21,8 +21,9 @@ def submit_feedback(feedback: FeedbackIn) -> Feedback:
 def get_feedback(
     job_id: Optional[str] = Query(None),
     agent_id: Optional[str] = Query(None),
+    user_id: Optional[str] = Query(None),
     start_ts: Optional[datetime] = Query(None),
     end_ts: Optional[datetime] = Query(None),
 ) -> List[Feedback]:
-    """Return feedback entries filtered by job, agent, and time."""
-    return list_feedback(job_id, agent_id, start_ts, end_ts)
+    """Return feedback entries filtered by job, agent, user, and time."""
+    return list_feedback(job_id, agent_id, user_id, start_ts, end_ts)

--- a/backend/app/services/feedback.py
+++ b/backend/app/services/feedback.py
@@ -47,6 +47,7 @@ def save_feedback(fb: FeedbackIn) -> Feedback:
 def list_feedback(
     job_id: Optional[str] = None,
     agent_id: Optional[str] = None,
+    user_id: Optional[str] = None,
     start_ts: Optional[datetime] = None,
     end_ts: Optional[datetime] = None,
 ) -> List[Feedback]:
@@ -62,6 +63,9 @@ def list_feedback(
         if agent_id:
             conditions.append("agent_id = %s")
             params.append(agent_id)
+        if user_id:
+            conditions.append("user_id = %s")
+            params.append(user_id)
         if start_ts:
             conditions.append("ts >= %s")
             params.append(start_ts)

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -30,9 +30,10 @@ def test_feedback_endpoints(monkeypatch) -> None:
         assert feedback.job_id == "job1"
         return sample
 
-    def fake_list(job_id=None, agent_id=None, start_ts=None, end_ts=None):
+    def fake_list(job_id=None, agent_id=None, user_id=None, start_ts=None, end_ts=None):
         assert job_id == "job1"
         assert agent_id == "agentA"
+        assert user_id == "userX"
         assert start_ts == now
         assert end_ts is None
         return [sample]
@@ -56,7 +57,12 @@ def test_feedback_endpoints(monkeypatch) -> None:
 
     resp2 = client.get(
         "/api/feedback",
-        params={"job_id": "job1", "agent_id": "agentA", "start_ts": now.isoformat()},
+        params={
+            "job_id": "job1",
+            "agent_id": "agentA",
+            "user_id": "userX",
+            "start_ts": now.isoformat(),
+        },
     )
     assert resp2.status_code == 200
     items = resp2.json()


### PR DESCRIPTION
## Summary
- allow `/api/feedback` to filter by `user_id`
- support user filter in feedback storage service
- test feedback endpoints including user filtering

## Testing
- `python -m py_compile app/**/*.py`
- `pytest backend/tests/test_feedback.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2068f9fb48330af7f588dcaaf2967