### PR TITLE
feat(jobspy): add scraping guardrails

### DIFF
--- a/jobspy_service/.env.example
+++ b/jobspy_service/.env.example
@@ -1,6 +1,10 @@
 # Example settings for the JobSpy service
 
-# Sources allowed by default: indeed, linkedin
+# Feature flag for enabling scraping
+JOBSPY_ENABLED=false
+
+# Comma-separated allowlist of job boards
+JOBSPY_SOURCES=indeed,linkedin
 
 # Delay (in seconds) before each scraping request
 JOBSPY_DELAY_SECONDS=1

--- a/jobspy_service/README.md
+++ b/jobspy_service/README.md
@@ -23,12 +23,14 @@ regardless of the upstream source. Each job contains the following fields:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `JOBSPY_SOURCES` | Comma-separated list of allowed providers. | `indeed,linkedin,google` |
-| `JOBSPY_ENABLED` | Toggle scraping feature. | `true` |
+| `JOBSPY_SOURCES` | Comma-separated allowlist of providers. | `indeed,linkedin,google` |
+| `JOBSPY_ENABLED` | Toggle scraping feature. | `false` |
 | `JOBSPY_DELAY_SECONDS` | Seconds to wait before making each scraping request. | `2` |
 | `JOBSPY_CACHE_TTL_SECONDS` | Seconds to cache job search results. | `600` |
 | `BIG_COMPANY_THRESHOLD` | Similarity cutoff for large companies during deduping. | `0.9` |
 | `SMALL_COMPANY_THRESHOLD` | Similarity cutoff for small companies during deduping. | `0.85` |
+
+Values outside the allowlist result in a server error.
 
 The delay helps avoid triggering provider rate limits. Adjust the value in your
 `.env` file if necessary. Recent search results are cached in-memory for the

--- a/jobspy_service/tests/test_ingest.py
+++ b/jobspy_service/tests/test_ingest.py
@@ -33,6 +33,26 @@ async def test_run_records_ingestion(monkeypatch, client):
 
 
 @pytest.mark.anyio
+async def test_results_capped_per_board(monkeypatch):
+    main.INGESTION_RUNS.clear()
+    main.BOARD_CONFIG["demo"] = {
+        "enabled": True,
+        "cadence": "4h",
+        "results_wanted_max": 3,
+        "hours_old": 24,
+        "delay": 0,
+    }
+    sample_job = {"title": "Dev"}
+    sample = {"jobs": [sample_job for _ in range(5)]}
+
+    with patch("jobspy_service.app.main.scrape_jobs", return_value=sample):
+        run = main.ingest_board("demo")
+
+    assert run.fetched == 3
+    assert run.normalized == 3
+
+
+@pytest.mark.anyio
 async def test_run_all_respects_cadence(monkeypatch, client):
     main.INGESTION_RUNS.clear()
     main.BOARD_CONFIG.clear()

--- a/jobspy_service/tests/test_jobs_integration.py
+++ b/jobspy_service/tests/test_jobs_integration.py
@@ -39,7 +39,12 @@ async def test_search_returns_schema_for_multiple_sources(monkeypatch, client):
         ],
     }
 
-    def fake_scrape(source: str, *, search_term: str | None = None):
+    def fake_scrape(
+        source: str,
+        *,
+        search_term: str | None = None,
+        results_wanted_max: int | None = None,
+    ) -> dict[str, object]:
         return {"jobs": raw_jobs[source], "source": source}
 
     for src in ("indeed", "linkedin"):
@@ -70,7 +75,12 @@ async def test_cached_query_returns_under_one_second(monkeypatch, client):
 
     calls = []
 
-    def fake_scrape(source: str, *, search_term: str | None = None):
+    def fake_scrape(
+        source: str,
+        *,
+        search_term: str | None = None,
+        results_wanted_max: int | None = None,
+    ) -> dict[str, object]:
         calls.append("scrape")
         return {"jobs": [], "source": source}
 


### PR DESCRIPTION
## Summary
- default JobSpy scraping to disabled and validate allowlisted sources
- enforce positive scraping delay and cap results per board
- document job scraping configuration

## Testing
- `python -m py_compile jobspy_service/app/*.py`
- `pytest jobspy_service/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68b208f9e9c483308154af2f8805fbb5