### PR TITLE
feat: add structured ingestion metrics

### DIFF
--- a/jobspy_service/tests/test_ingest.py
+++ b/jobspy_service/tests/test_ingest.py
@@ -29,7 +29,11 @@ async def test_run_records_ingestion(monkeypatch, client):
     body = response.json()
     assert body["board"] == "demo"
     assert body["fetched"] == 1
+    assert "run_id" in body
     assert len(main.INGESTION_RUNS) == 1
+    list_resp = await client.get("/ingest/runs")
+    runs = list_resp.json()
+    assert any(r["run_id"] == body["run_id"] for r in runs)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- log ingestion stages with run-specific IDs and durations
- persist ingestion metrics and expose listing endpoint
- verify metrics and run IDs in tests

## Testing
- `python -m py_compile app/*.py`
- `python -m py_compile jobspy_service/tests/test_ingest.py`
- `pytest tests/test_ingest.py::test_run_records_ingestion tests/test_ingest.py::test_results_capped_per_board tests/test_ingest.py::test_run_all_respects_cadence -q`


------
https://chatgpt.com/codex/tasks/task_e_68b20bf130fc8330b98f7967a6c6420d