### PR TITLE
fix: handle malformed evaluation output parsing

### DIFF
--- a/backend/tests/test_parse_output.py
+++ b/backend/tests/test_parse_output.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app.services.evaluation import _parse_output
+
+
+def test_parse_output_valid() -> None:
+    vote, rationale = _parse_output("Vote: Yes\nRationale: strong match")
+    assert vote is True
+    assert rationale == "strong match"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "Approval: Yes\nRationale: good",
+        "Vote: Maybe\nRationale: unsure",
+        "Random text",
+    ],
+)
+def test_parse_output_invalid(raw: str) -> None:
+    with pytest.raises(ValueError):
+        _parse_output(raw)
+
+
+def test_parse_output_missing_rationale() -> None:
+    vote, rationale = _parse_output("Vote: No")
+    assert vote is False
+    assert rationale == ""


### PR DESCRIPTION
## Summary
- raise clear errors for malformed evaluation LLM output
- add tests to verify `_parse_output` behavior with malformed inputs

## Testing
- `python -m py_compile app/**/*.py`
- `python -m py_compile tests/test_parse_output.py`
- `pytest backend/tests/test_parse_output.py backend/tests/test_evaluation_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21b512cc083308d2cc04589b97fd8