### PR TITLE
chore: avoid duplicate CI runs

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,8 +1,9 @@
 name: Backend Tests
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]  # or remove this section if you only need PR runs
 
 jobs:
   backend:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]  # or remove this section if you only need PR runs
 
 jobs:
   smoke:

--- a/.github/workflows/job-search-tests.yml
+++ b/.github/workflows/job-search-tests.yml
@@ -1,8 +1,9 @@
 name: Job Search Tests
 
 on:
-  push:
   pull_request:
+  push:
+    branches: [main]  # or remove this section if you only need PR runs
 
 jobs:
   jobspy-tests:


### PR DESCRIPTION
## Summary
- prevent duplicate backend, CI, and job search workflows by only running on pull requests and main branch pushes

## Testing
- `python -c 'import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]' .github/workflows/backend-tests.yml .github/workflows/ci.yml .github/workflows/job-search-tests.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b21f38f17c83308d294994a0628b7d