### PR TITLE
feat: add job discovery endpoints

### DIFF
--- a/backend/app/models/job.py
+++ b/backend/app/models/job.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from typing import List
 
 
 class Job(BaseModel):
@@ -13,6 +14,7 @@ class Job(BaseModel):
     url: str | None = None
     source: str | None = None
     updated_at: datetime | None = None
+    decision: str | None = None
 
 
 class EvaluationSummary(BaseModel):
@@ -30,3 +32,48 @@ class JobDetail(Job):
     description: str | None = None
     location: str | None = None
     evaluation: EvaluationSummary
+
+
+class JobCreate(BaseModel):
+    """Input model for logging an external job."""
+
+    title: str
+    company: str
+    url: str
+    location: str | None = None
+    description: str | None = None
+
+
+class JobCreateResponse(BaseModel):
+    """Response model for a logged job."""
+
+    id: str = Field(alias="job_id")
+    status: str
+    created_at: datetime
+
+
+class PageMeta(BaseModel):
+    """Metadata for paginated responses."""
+
+    page: int
+    page_count: int
+    total: int
+
+
+class JobOut(BaseModel):
+    """Output model with user-facing field names."""
+
+    id: str
+    title: str | None = None
+    company: str | None = None
+    url: str | None = None
+    source: str | None = None
+    updated_at: datetime | None = None
+    decision: str | None = None
+
+
+class JobListResponse(BaseModel):
+    """Paginated list of jobs."""
+
+    data: List[JobOut]
+    meta: PageMeta

--- a/backend/app/routes/evaluate.py
+++ b/backend/app/routes/evaluate.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
-from typing import List
+from fastapi import APIRouter, HTTPException
 
-from fastapi import APIRouter
-
-from ..models.evaluation import PersonaEvaluation
-from ..services.evaluation import evaluate_job
+from ..services.evaluation import (
+    JobNotFoundError,
+    QueueError,
+    queue_job_evaluation,
+)
 
 router = APIRouter()
 
 
-@router.post("/api/evaluate/job/{job_id}", response_model=List[PersonaEvaluation])
-def evaluate(job_id: str) -> List[PersonaEvaluation]:
-    """Trigger motivational personas to evaluate a job."""
-    return evaluate_job(job_id)
+@router.post("/api/evaluate/job/{job_id}", status_code=202)
+def evaluate(job_id: str) -> dict[str, str]:
+    """Trigger non-blocking evaluation of a job."""
+    try:
+        queue_job_evaluation(job_id)
+    except JobNotFoundError:
+        raise HTTPException(status_code=404, detail="job not found")
+    except QueueError:
+        raise HTTPException(status_code=500, detail="queue failure")
+    return {"status": "queued", "job_id": job_id}

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -5,7 +5,12 @@ import sys
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
 from backend.app.services import jobs as jobs_service
-from backend.app.models.job import Job, JobDetail, EvaluationSummary
+from backend.app.models.job import (
+    EvaluationSummary,
+    Job,
+    JobCreateResponse,
+    JobDetail,
+)
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -18,7 +23,17 @@ class FakeCursorList:
         self.calls.append((query, params))
 
     def fetchall(self):
-        return [("id1", "Engineer", "Acme", "http://a", "indeed", datetime(2024, 1, 1))]
+        return [
+            (
+                "id1",
+                "Engineer",
+                "Acme",
+                "http://a",
+                "indeed",
+                datetime(2024, 1, 1),
+                "undecided",
+            )
+        ]
 
     def close(self) -> None:  # pragma: no cover - no action
         pass
@@ -82,12 +97,19 @@ class FakeConnDetail:
 
 def test_list_unique_jobs(monkeypatch) -> None:
     fake = FakeConnList()
+
+    def fake_fetchone():
+        return (1,)
+
+    fake.cursor_obj.fetchone = fake_fetchone  # type: ignore[attr-defined]
     monkeypatch.setattr(jobs_service, "_get_conn", lambda: fake)
-    jobs = jobs_service.list_unique_jobs()
+    jobs, total = jobs_service.list_unique_jobs()
+    assert total == 1
     assert len(jobs) == 1
     job = jobs[0]
     assert isinstance(job, Job)
     assert job.job_id == "id1"
+    assert job.decision == "undecided"
 
 
 def test_get_job_detail(monkeypatch) -> None:
@@ -108,16 +130,20 @@ def test_jobs_api(monkeypatch) -> None:
     monkeypatch.setattr(
         jobs_route,
         "list_unique_jobs",
-        lambda **_: [
-            Job(
-                job_id="id1",
-                title="Engineer",
-                company="Acme",
-                url="http://a",
-                source="indeed",
-                updated_at=datetime(2024, 1, 1),
-            )
-        ],
+        lambda **_: (
+            [
+                Job(
+                    job_id="id1",
+                    title="Engineer",
+                    company="Acme",
+                    url="http://a",
+                    source="indeed",
+                    updated_at=datetime(2024, 1, 1),
+                    decision="undecided",
+                )
+            ],
+            1,
+        ),
     )
     monkeypatch.setattr(
         jobs_route,
@@ -134,13 +160,43 @@ def test_jobs_api(monkeypatch) -> None:
             evaluation=EvaluationSummary(yes=2, no=1, final_decision_bool=True, confidence=0.9),
         ),
     )
+    monkeypatch.setattr(
+        jobs_route,
+        "create_job",
+        lambda payload: JobCreateResponse(job_id="id2", status="logged", created_at=datetime(2024, 1, 1)),
+    )
     app.include_router(jobs_route.router)
     client = TestClient(app)
     resp = client.get("/api/jobs/unique")
     assert resp.status_code == 200
     data = resp.json()
-    assert data[0]["job_id"] == "id1"
+    assert data["data"][0]["id"] == "id1"
+    assert data["meta"]["total"] == 1
     resp = client.get("/api/jobs/id1")
     assert resp.status_code == 200
     detail = resp.json()
     assert detail["evaluation"]["yes"] == 2
+    resp = client.post(
+        "/api/jobs",
+        json={"title": "Eng", "company": "Acme", "url": "http://a"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status"] == "logged"
+
+
+def test_log_job_duplicate(monkeypatch) -> None:
+    app = FastAPI()
+    from backend.app.routes import jobs as jobs_route
+
+    def dup(_payload):
+        raise ValueError("duplicate job")
+
+    monkeypatch.setattr(jobs_route, "create_job", dup)
+    app.include_router(jobs_route.router)
+    client = TestClient(app)
+    resp = client.post(
+        "/api/jobs",
+        json={"title": "Eng", "company": "Acme", "url": "http://a"},
+    )
+    assert resp.status_code == 409


### PR DESCRIPTION
## Summary
- add paginated job listing with filters and decision visibility
- queue job evaluations asynchronously
- allow manual logging of external job leads

## Testing
- `python -m py_compile app/**/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b229eba2208330b41f3296ff9f8dde