### PR TITLE
feat(frontend): add job discovery UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "@tanstack/react-query": "^5.0.0",
+    "react-hot-toast": "^2.4.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/components/AddJobModal.jsx
+++ b/frontend/src/components/AddJobModal.jsx
@@ -1,12 +1,75 @@
+import { useState } from 'react';
+import toast from 'react-hot-toast';
 import styles from './AddJobModal.module.css';
 
-export default function AddJobModal({ onClose }) {
+export default function AddJobModal({ onClose, onSaved }) {
+  const [form, setForm] = useState({
+    title: '',
+    company: '',
+    url: '',
+    location: '',
+    description: '',
+  });
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const res = await fetch('/api/jobs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        toast.success('Job added');
+        onSaved?.();
+        onClose();
+      } else {
+        toast.error('Failed to add job');
+      }
+    } catch (err) {
+      toast.error('Failed to add job');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
     <div className={styles.backdrop} role="dialog" aria-modal="true">
       <div className={styles.modal}>
         <h2>Add Job</h2>
-        <p>Job form goes here.</p>
-        <button onClick={onClose}>Close</button>
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <label>
+            Job Title
+            <input name="title" value={form.title} onChange={handleChange} required />
+          </label>
+          <label>
+            Company
+            <input name="company" value={form.company} onChange={handleChange} required />
+          </label>
+          <label>
+            URL
+            <input name="url" value={form.url} onChange={handleChange} required />
+          </label>
+          <label>
+            Location
+            <input name="location" value={form.location} onChange={handleChange} />
+          </label>
+          <label>
+            Description
+            <textarea name="description" value={form.description} onChange={handleChange} />
+          </label>
+          <div className={styles.actions}>
+            <button type="button" onClick={onClose}>Cancel</button>
+            <button type="submit" disabled={submitting}>Save</button>
+          </div>
+        </form>
       </div>
     </div>
   );

--- a/frontend/src/components/AddJobModal.module.css
+++ b/frontend/src/components/AddJobModal.module.css
@@ -11,9 +11,39 @@
   background: white;
   padding: 1rem;
   border-radius: 0.5rem;
-  min-width: 200px;
+  min-width: 300px;
 }
 
 .modal button:focus {
   outline: 2px solid #000;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.875rem;
+  gap: 0.25rem;
+}
+
+.form input,
+.form textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.actions button {
+  padding: 0.5rem 1rem;
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from 'react-hot-toast';
 import App from './App';
+
+const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+        <Toaster />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/frontend/src/pages/Discover.jsx
+++ b/frontend/src/pages/Discover.jsx
@@ -1,48 +1,172 @@
-import JobCard from '../components/JobCard';
+import { useState, useEffect } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import AddJobModal from '../components/AddJobModal';
 import styles from './Discover.module.css';
 
-const sampleJobs = [
-  {
-    company: 'Amazon',
-    title: 'Senior UI Designer',
-    location: 'Remote',
-    posted: 'Jan 25, 2025'
-  },
-  {
-    company: 'Google',
-    title: 'Product Designer',
-    location: 'San Francisco, CA',
-    posted: 'Jan 26, 2025'
-  },
-  {
-    company: 'Apple',
-    title: 'UX/UI Designer',
-    location: 'Cupertino, CA',
-    posted: 'Jan 20, 2025'
-  },
-  {
-    company: 'Netflix',
-    title: 'Frontend Developer',
-    location: 'Los Gatos, CA',
-    posted: 'Jan 18, 2025'
-  }
-];
+const fetchJobs = async (params) => {
+  const res = await fetch(`/api/jobs/unique?${params.toString()}`);
+  if (!res.ok) throw new Error('failed');
+  return res.json();
+};
 
 export default function Discover() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [showModal, setShowModal] = useState(false);
+  const [search, setSearch] = useState(searchParams.get('query') || '');
+  const [source, setSource] = useState(searchParams.get('source') || '');
+  const [since, setSince] = useState(searchParams.get('since') || '');
+  const hide = searchParams.get('hide')?.split(',') ?? [];
+  const [hideRejected, setHideRejected] = useState(hide.includes('rejected'));
+  const [hideBadFit, setHideBadFit] = useState(hide.includes('bad_fit'));
+  const queryClient = useQueryClient();
+
+  const page = Number(searchParams.get('page') || 1);
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      const next = new URLSearchParams(searchParams);
+      if (search) next.set('query', search);
+      else next.delete('query');
+      next.set('page', '1');
+      setSearchParams(next);
+    }, 500);
+    return () => clearTimeout(id);
+  }, [search]);
+
+  useEffect(() => {
+    const next = new URLSearchParams(searchParams);
+    if (source) next.set('source', source); else next.delete('source');
+    if (since) next.set('since', since); else next.delete('since');
+    const hides = [];
+    if (hideRejected) hides.push('rejected');
+    if (hideBadFit) hides.push('bad_fit');
+    if (hides.length) next.set('hide', hides.join(','));
+    else next.delete('hide');
+    next.set('page', '1');
+    setSearchParams(next);
+  }, [source, since, hideRejected, hideBadFit]);
+
+  const { data, isLoading } = useQuery(
+    ['jobs', searchParams.toString()],
+    () => fetchJobs(searchParams),
+    { keepPreviousData: true, staleTime: 30000 }
+  );
+
+  const handleAnalyze = async (id) => {
+    await fetch(`/api/evaluate/job/${id}`, { method: 'POST' });
+    toast.success('Evaluation started');
+    setTimeout(() => queryClient.invalidateQueries(['jobs']), 1000);
+  };
+
+  const nextPage = () => {
+    const next = new URLSearchParams(searchParams);
+    next.set('page', String(page + 1));
+    setSearchParams(next);
+  };
+
+  const prevPage = () => {
+    const next = new URLSearchParams(searchParams);
+    next.set('page', String(page - 1));
+    setSearchParams(next);
+  };
+
   return (
     <div className={styles.discover}>
-      <form className={styles.searchForm} onSubmit={e => e.preventDefault()}>
-        <input type="text" placeholder="Job Title / Keywords" />
-        <input type="text" placeholder="Location" />
-        <input type="text" placeholder="Experience Level" />
-        <input type="text" placeholder="Job Type" />
-        <button type="submit">Search</button>
-      </form>
-      <div className={styles.grid}>
-        {sampleJobs.map(job => (
-          <JobCard key={job.title} {...job} />
-        ))}
+      <div className={styles.toolbar}>
+        <input
+          type="text"
+          placeholder="Search jobs"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="Search jobs"
+        />
+        <select value={source} onChange={(e) => setSource(e.target.value)} aria-label="Source">
+          <option value="">All Sources</option>
+          <option value="LinkedIn">LinkedIn</option>
+          <option value="Indeed">Indeed</option>
+        </select>
+        <select value={since} onChange={(e) => setSince(e.target.value)} aria-label="Since">
+          <option value="">Any time</option>
+          <option value="24h">Last 24h</option>
+          <option value="7d">Last 7d</option>
+          <option value="30d">Last 30d</option>
+        </select>
+        <label>
+          <input
+            type="checkbox"
+            checked={hideRejected}
+            onChange={(e) => setHideRejected(e.target.checked)}
+          />
+          Hide Rejected
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={hideBadFit}
+            onChange={(e) => setHideBadFit(e.target.checked)}
+          />
+          Hide Bad Fit
+        </label>
+        <button onClick={() => setShowModal(true)}>Add Job</button>
       </div>
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : data.data.length === 0 ? (
+        <p>
+          No jobs yet — click{' '}
+          <button onClick={() => setShowModal(true)}>Add Job</button> to get started.
+        </p>
+      ) : (
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th scope="col">Job Title</th>
+              <th scope="col">Company</th>
+              <th scope="col">Source</th>
+              <th scope="col">Updated</th>
+              <th scope="col">Decision</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.data.map((job) => (
+              <tr key={job.id}>
+                <td>
+                  <Link to={`/jobs/${job.id}`}>{job.title}</Link>
+                </td>
+                <td>{job.company}</td>
+                <td>{job.source}</td>
+                <td>{new Date(job.updated_at).toLocaleString()}</td>
+                <td>
+                  <span className={styles.decision}>{job.decision}</span>
+                </td>
+                <td>
+                  <button onClick={() => handleAnalyze(job.id)}>Analyze</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {data && data.meta && (
+        <div className={styles.pagination}>
+          <button onClick={prevPage} disabled={page <= 1}>
+            Prev
+          </button>
+          <span>Page {page}</span>
+          <button onClick={nextPage} disabled={page >= data.meta.page_count}>
+            Next
+          </button>
+        </div>
+      )}
+      {showModal && (
+        <AddJobModal
+          onClose={() => setShowModal(false)}
+          onSaved={() => queryClient.invalidateQueries(['jobs'])}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Discover.module.css
+++ b/frontend/src/pages/Discover.module.css
@@ -1,34 +1,74 @@
 .discover {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-}
-
-.searchForm {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
 }
 
-.searchForm input {
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.toolbar input {
   border: 1px solid #d1d5db;
   border-radius: 0.375rem;
   padding: 0.5rem;
 }
 
-.searchForm button {
+.toolbar select {
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+}
+
+.toolbar label {
+  display: flex;
+  gap: 0.25rem;
+  align-items: center;
+}
+
+.toolbar button {
   background: #000;
   color: #fff;
   border-radius: 0.375rem;
   padding: 0.5rem 1rem;
 }
 
-.searchForm button:focus {
+.toolbar button:focus {
   outline: 2px solid #000;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 1rem;
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.table th {
+  text-align: left;
+}
+
+.decision {
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  background: #e5e7eb;
+  font-size: 0.75rem;
+}
+
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.pagination button:focus {
+  outline: 2px solid #000;
 }


### PR DESCRIPTION
## Summary
- add React Query and toast providers
- implement job discovery table with filters and analysis action
- add modal to log new jobs

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2283609b48330ad5d1c980d17d0e2