### PR TITLE
fix(frontend): build assets in Docker and respect env port

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,13 @@
-# Static placeholder; swap to your real build later
+FROM node:18 AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
 FROM nginx:alpine
-COPY public /usr/share/nginx/html
-EXPOSE 80
+ARG FRONTEND_PORT=80
+ENV FRONTEND_PORT=${FRONTEND_PORT}
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE ${FRONTEND_PORT}
+


### PR DESCRIPTION
## Summary
- build React frontend during Docker image creation
- expose frontend on configurable port, defaulting to 80

## Testing
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b231b85c008330b70d5b7b36ee75f9