### PR TITLE
chore(frontend): install deps without package lock

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,10 @@
-# Static placeholder; swap to your real build later
+FROM node:18 AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
 FROM nginx:alpine
-COPY public /usr/share/nginx/html
+COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80


### PR DESCRIPTION
## Summary
- build frontend with Node then serve via nginx
- copy only package.json and install dependencies without package lock

## Testing
- `docker compose build frontend --no-cache` *(fails: command not found: docker)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b23be1fd9c8330bd4a901a998b64f9