### PR TITLE
feat(frontend): add jobs discovery with filters and actions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "@tanstack/react-query": "^5.51.21"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
-    "@tanstack/react-query": "^5.51.21"
+    "@tanstack/react-query": "5.51.21"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/src/components/AddJobModal.module.css
+++ b/frontend/src/components/AddJobModal.module.css
@@ -12,3 +12,8 @@
   max-width: 90%;
   border-radius: 4px;
 }
+.modal form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/frontend/src/components/AddJobModal.tsx
+++ b/frontend/src/components/AddJobModal.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import styles from './AddJobModal.module.css';
 
 interface Props {
@@ -7,6 +8,15 @@ interface Props {
 
 export default function AddJobModal({ onClose }: Props) {
   const ref = useRef<HTMLDivElement>(null);
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState({
+    title: '',
+    company: '',
+    url: '',
+    location: '',
+    description: '',
+  });
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const previous = document.activeElement as HTMLElement | null;
@@ -43,12 +53,85 @@ export default function AddJobModal({ onClose }: Props) {
     };
   }, [onClose]);
 
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    const resp = await fetch('/api/jobs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: form.title,
+        company: form.company,
+        url: form.url,
+        location: form.location || undefined,
+        description: form.description || undefined,
+      }),
+    });
+    if (!resp.ok) {
+      setError('Failed to save job');
+      return;
+    }
+    queryClient.invalidateQueries({ queryKey: ['jobs'] });
+    onClose();
+  };
+
   return (
     <div className={styles.backdrop} role="dialog" aria-modal="true" onClick={onClose}>
       <div className={styles.modal} ref={ref} onClick={(e) => e.stopPropagation()}>
         <h2 id="add-job-title">Add Job</h2>
-        <p>Modal placeholder</p>
-        <button onClick={onClose}>Close</button>
+        <form onSubmit={handleSubmit}>
+          <label>
+            Job Title
+            <input
+              name="title"
+              value={form.title}
+              onChange={handleChange}
+              required
+            />
+          </label>
+          <label>
+            Company
+            <input
+              name="company"
+              value={form.company}
+              onChange={handleChange}
+              required
+            />
+          </label>
+          <label>
+            URL
+            <input
+              name="url"
+              type="url"
+              value={form.url}
+              onChange={handleChange}
+              required
+            />
+          </label>
+          <label>
+            Location
+            <input name="location" value={form.location} onChange={handleChange} />
+          </label>
+          <label>
+            Description
+            <textarea
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+            />
+          </label>
+          {error && <p role="alert">{error}</p>}
+          <div>
+            <button type="submit">Save</button>
+            <button type="button" onClick={onClose}>
+              Cancel
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   );

--- a/frontend/src/components/Toast.module.css
+++ b/frontend/src/components/Toast.module.css
@@ -1,0 +1,9 @@
+.toast {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: #333;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import styles from './Toast.module.css';
+
+interface Props {
+  message: string;
+  onDismiss: () => void;
+}
+
+export default function Toast({ message, onDismiss }: Props) {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, 3000);
+    return () => clearTimeout(timer);
+  }, [onDismiss]);
+
+  return (
+    <div className={styles.toast} role="status" aria-live="polite">
+      {message}
+    </div>
+  );
+}

--- a/frontend/src/layouts/JobsLayout.tsx
+++ b/frontend/src/layouts/JobsLayout.tsx
@@ -1,13 +1,29 @@
-import { Outlet, useLocation } from 'react-router-dom';
-import { useState } from 'react';
+import { Outlet, useLocation, useSearchParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import JobsNav from '../components/JobsNav';
 import AddJobModal from '../components/AddJobModal';
 import styles from './JobsLayout.module.css';
 
 export default function JobsLayout() {
   const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [search, setSearch] = useState(searchParams.get('query') || '');
   const [showModal, setShowModal] = useState(false);
   const isSearchVisible = /\/jobs\/(discover|shortlist)/.test(location.pathname);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      const params = new URLSearchParams(searchParams);
+      if (search) {
+        params.set('query', search);
+      } else {
+        params.delete('query');
+      }
+      setSearchParams(params, { replace: true });
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [search, searchParams, setSearchParams]);
+
   return (
     <div>
       <JobsNav />
@@ -18,6 +34,8 @@ export default function JobsLayout() {
             placeholder="Search jobs"
             aria-label="Search jobs"
             className={styles.search}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
           />
         )}
         <button className={styles.addButton} onClick={() => setShowModal(true)}>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,11 +3,16 @@ import ReactDOM from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <HashRouter>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </HashRouter>
   </React.StrictMode>,
 );

--- a/frontend/src/pages/JobsDiscoverPage.module.css
+++ b/frontend/src/pages/JobsDiscoverPage.module.css
@@ -1,0 +1,29 @@
+.filters {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.table th,
+.table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #ccc;
+}
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+.pill {
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  background: #eee;
+}
+.pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}

--- a/frontend/src/pages/JobsDiscoverPage.tsx
+++ b/frontend/src/pages/JobsDiscoverPage.tsx
@@ -1,13 +1,198 @@
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import Toast from '../components/Toast';
+import styles from './JobsDiscoverPage.module.css';
+
+interface Job {
+  id: string;
+  title?: string;
+  company?: string;
+  source?: string;
+  updated_at?: string;
+  decision?: string;
+}
+
+interface JobListResponse {
+  data: Job[];
+  meta: { page: number; page_count: number; total: number };
+}
+
+function formatRelative(value?: string) {
+  if (!value) return '';
+  const date = new Date(value);
+  const diff = Date.now() - date.getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
 
 export default function JobsDiscoverPage() {
   const location = useLocation();
+  const queryClient = useQueryClient();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [toast, setToast] = useState('');
+
+  const page = Number(searchParams.get('page') || 1);
+  const query = searchParams.get('query') || '';
+  const since = searchParams.get('since') || '';
+  const selectedSources = searchParams.getAll('source');
+  const hide = searchParams.get('hide') === '1';
+
+  const params = new URLSearchParams();
+  if (query) params.set('query', query);
+  selectedSources.forEach((s) => params.append('source', s));
+  if (since) params.set('since', since);
+  if (hide) {
+    params.append('hide', 'rejected');
+    params.append('hide', 'bad_fit');
+  }
+  params.set('page', String(page));
+
+  const { data, isLoading, error } = useQuery<JobListResponse>({
+    queryKey: ['jobs', params.toString()],
+    queryFn: async () => {
+      const resp = await fetch(`/api/jobs/unique?${params.toString()}`);
+      if (!resp.ok) throw new Error('failed');
+      return resp.json();
+    },
+    keepPreviousData: true,
+    staleTime: 30000,
+  });
+
+  const sources = Array.from(
+    new Set((data?.data || []).map((j) => j.source).filter(Boolean))
+  ) as string[];
+
+  const updateParams = (
+    updates: Record<string, string | string[] | null>
+  ) => {
+    const next = new URLSearchParams(searchParams);
+    Object.entries(updates).forEach(([k, v]) => {
+      next.delete(k);
+      if (Array.isArray(v)) v.forEach((item) => next.append(k, item));
+      else if (v) next.set(k, v);
+    });
+    if (updates.page === undefined) next.set('page', '1');
+    setSearchParams(next, { replace: true });
+  };
+
+  const handleAnalyze = async (id: string) => {
+    await fetch(`/api/evaluate/job/${id}`, { method: 'POST' });
+    setToast('Evaluation started');
+    setTimeout(() => {
+      queryClient.invalidateQueries({ queryKey: ['jobs'] });
+    }, 1000);
+  };
+
+  const onPage = (p: number) => updateParams({ page: String(p) });
+
   return (
     <div>
       <h1>Discover Jobs</h1>
-      <ul>
-        <li><Link to="/jobs/1" state={{ backgroundLocation: location }}>Sample Job 1</Link></li>
-      </ul>
+      <div className={styles.filters}>
+        <label>
+          Source
+          <select
+            multiple
+            value={selectedSources}
+            onChange={(e) => {
+              const opts = Array.from(e.target.selectedOptions).map((o) => o.value);
+              updateParams({ source: opts });
+            }}
+          >
+            {sources.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Since
+          <select
+            value={since}
+            onChange={(e) => updateParams({ since: e.target.value || null })}
+          >
+            <option value="">Any time</option>
+            <option value="24h">Last 24h</option>
+            <option value="7d">Last 7d</option>
+            <option value="30d">Last 30d</option>
+          </select>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={hide}
+            onChange={() => updateParams({ hide: hide ? null : '1' })}
+          />{' '}
+          Hide Rejected/Bad Fit
+        </label>
+      </div>
+      {isLoading && <p>Loading...</p>}
+      {error && <p role="alert">Error loading jobs</p>}
+      {!isLoading && data && data.data.length === 0 && (
+        <p>No jobs yet — click Add Job to get started.</p>
+      )}
+      {data && data.data.length > 0 && (
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th scope="col">Job Title</th>
+              <th scope="col">Company</th>
+              <th scope="col">Source</th>
+              <th scope="col">Updated</th>
+              <th scope="col">Decision</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.data.map((job) => (
+              <tr key={job.id}>
+                <td>
+                  <Link
+                    to={`/jobs/${job.id}`}
+                    state={{ backgroundLocation: location }}
+                  >
+                    {job.title}
+                  </Link>
+                </td>
+                <td>{job.company}</td>
+                <td>{job.source}</td>
+                <td>{formatRelative(job.updated_at)}</td>
+                <td>
+                  {job.decision && (
+                    <span className={styles.pill}>{job.decision}</span>
+                  )}
+                </td>
+                <td className={styles.actions}>
+                  <button onClick={() => handleAnalyze(job.id)}>Analyze</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      {data && data.meta.page_count > 1 && (
+        <nav className={styles.pagination} aria-label="Pagination">
+          <button onClick={() => onPage(page - 1)} disabled={page <= 1}>
+            Previous
+          </button>
+          <span>
+            Page {data.meta.page} of {data.meta.page_count}
+          </span>
+          <button
+            onClick={() => onPage(page + 1)}
+            disabled={page >= data.meta.page_count}
+          >
+            Next
+          </button>
+        </nav>
+      )}
+      {toast && <Toast message={toast} onDismiss={() => setToast('')} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- list jobs with filters, pagination, and analysis actions
- allow adding external jobs via modal form
- wire search box to URL query params with debounce

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2a6c666908330904da56fbef52a81